### PR TITLE
v3.2.0: support for teams when using server roles, and some small changes

### DIFF
--- a/QuizBowlDiscordScoreTracker/Bot.cs
+++ b/QuizBowlDiscordScoreTracker/Bot.cs
@@ -1,17 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
-using Discord.Net;
 using Discord.Rest;
 using Discord.WebSocket;
 using Microsoft.AspNetCore.SignalR;
@@ -24,27 +19,22 @@ using Serilog;
 
 namespace QuizBowlDiscordScoreTracker
 {
-    // TODO: Refactor this so that most of the methods are in a separate class that is easily testable.
     public sealed class Bot : BackgroundService
     {
-        private static readonly Regex BuzzRegex = new Regex("^\\s*bu?z+\\s*$", RegexOptions.IgnoreCase);
-
         // TODO: We may need a lock for this, and this lock would need to be accessible form BotCommands. We could wrap
         // this in an object which would do the locking for us.
         private readonly GameStateManager gameStateManager;
         private readonly IOptionsMonitor<BotConfiguration> options;
         private readonly DiscordSocketClient client;
         private readonly IServiceProvider serviceProvider;
-        private readonly IEnumerable<Regex> buzzEmojisRegex;
         private readonly ILogger logger;
         private readonly DiscordNetEventLogger discordNetEventLogger;
         private readonly IDisposable configurationChangeCallback;
         private readonly IDatabaseActionFactory dbActionFactory;
+        private readonly MessageHandler messageHandler;
 
         [SuppressMessage("Code Quality", "CA2213:Disposable fields should be disposed", Justification = "Dispose method is inaccessible")]
         private readonly CommandService commandService;
-
-        private readonly IHubContext<MonitorHub> hubContext;
 
         private readonly Dictionary<IGuildUser, bool> readerRejoinedMap;
         private readonly object readerRejoinedMapLock = new object();
@@ -58,15 +48,9 @@ namespace QuizBowlDiscordScoreTracker
                 throw new ArgumentNullException(nameof(options));
             }
 
-            this.hubContext = hubContext;
             this.gameStateManager = new GameStateManager();
             this.options = options;
             this.dbActionFactory = new SqliteDatabaseActionFactory(this.options.CurrentValue.DatabaseDataSource);
-
-            // TODO: Rewrite this so that
-            // #1: buzz emojis are server-dependent, since emojis are
-            // #2: This can be updated if the config file is refreshed.
-            this.buzzEmojisRegex = BuildBuzzEmojiRegexes(this.options.CurrentValue);
             this.readerRejoinedMap = new Dictionary<IGuildUser, bool>();
 
             DiscordSocketConfig clientConfig = new DiscordSocketConfig()
@@ -95,6 +79,8 @@ namespace QuizBowlDiscordScoreTracker
 
             Task.WaitAll(this.commandService.AddModulesAsync(Assembly.GetExecutingAssembly(), this.serviceProvider));
 
+            this.messageHandler = new MessageHandler(this.options, this.dbActionFactory, hubContext, this.logger);
+
             this.client.MessageReceived += this.OnMessageCreated;
             this.client.GuildMemberUpdated += this.OnPresenceUpdated;
 
@@ -118,28 +104,6 @@ namespace QuizBowlDiscordScoreTracker
             this.configurationChangeCallback.Dispose();
             this.client.Dispose();
             base.Dispose();
-        }
-
-        private static IEnumerable<Regex> BuildBuzzEmojiRegexes(BotConfiguration options)
-        {
-            if (options.BuzzEmojis == null)
-            {
-                return Array.Empty<Regex>();
-            }
-
-            List<Regex> result = new List<Regex>();
-            StringBuilder builder = new StringBuilder();
-            foreach (string buzzEmoji in options.BuzzEmojis)
-            {
-                builder.Append("^<");
-                builder.Append(buzzEmoji);
-                builder.Append("\\d+>$");
-                Regex regex = new Regex(builder.ToString());
-                result.Add(regex);
-                builder.Clear();
-            }
-
-            return result;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -166,83 +130,9 @@ namespace QuizBowlDiscordScoreTracker
             return base.StopAsync(cancellationToken);
         }
 
-        private async Task<Tuple<IVoiceChannel, IGuildUser>> MuteReader(ITextChannel textChannel, ulong? readerId)
-        {
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
-            ulong? voiceChannelId = null;
-            using (DatabaseAction action = this.dbActionFactory.Create())
-            {
-                voiceChannelId = await action.GetPairedVoiceChannelIdOrNullAsync(textChannel.Id);
-            }
-
-            stopwatch.Stop();
-            this.logger.Verbose($"Time to get paired channel: {stopwatch.ElapsedMilliseconds} ms");
-
-            if (voiceChannelId == null)
-            {
-                return null;
-            }
-
-            IVoiceChannel voiceChannel = await textChannel.Guild.GetVoiceChannelAsync(voiceChannelId.Value);
-            if (voiceChannel == null)
-            {
-                return null;
-            }
-
-            IGuildUser reader = await textChannel.Guild.GetUserAsync(readerId.Value);
-            try
-            {
-                // Make sure the reader didn't mute themselves or leave the voice channel
-                if (!reader.IsSelfMuted && reader.VoiceChannel?.Id == voiceChannel.Id)
-                {
-                    await reader.ModifyAsync(properties => properties.Mute = true);
-                }
-            }
-            catch (HttpException ex)
-            {
-                if (ex.HttpCode == System.Net.HttpStatusCode.Forbidden)
-                {
-                    this.logger.Error(
-                        $"Couldn't deafen reader because bot doesn't have Mute permission in guild '{voiceChannel.Guild.Name}'");
-                }
-
-                return null;
-            }
-
-            return new Tuple<IVoiceChannel, IGuildUser>(voiceChannel, reader);
-        }
-
-        private async Task PromptNextPlayerAsync(GameState state, ITextChannel textChannel)
-        {
-            if (state.TryGetNextPlayer(out ulong userId))
-            {
-                IGuildUser user = await textChannel.Guild.GetUserAsync(userId);
-                Task<Tuple<IVoiceChannel, IGuildUser>> getVoiceChannelReaderPair = this.MuteReader(
-                    textChannel, state.ReaderId);
-                Task sendMessage = textChannel.SendMessageAsync(user.Mention);
-                Task alertWebSocket = this.hubContext.Clients.Group(GroupFromChannel(textChannel))
-                    .SendAsync("PlayerBuzz", user.Nickname ?? user.Username);
-                await Task.WhenAll(getVoiceChannelReaderPair, sendMessage, alertWebSocket);
-
-                Tuple<IVoiceChannel, IGuildUser> voiceChannelReaderPair = getVoiceChannelReaderPair.Result;
-                if (voiceChannelReaderPair != null)
-                {
-                    // We want to run this on a separate thread and not block the event handler
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                    Task.Run(() => this.UnmuteReaderAfterDelayAsync(voiceChannelReaderPair.Item1, voiceChannelReaderPair.Item2));
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                }
-            }
-            else
-            {
-                await this.hubContext.Clients.Group(GroupFromChannel(textChannel)).SendAsync("Clear");
-            }
-        }
-
         private async Task OnMessageCreated(SocketMessage message)
         {
-            // Help in DM needs this fixed
+            // Ignore messages from the bot or from non user messages (in channel or DMs).
             if (message.Author.Id == this.client.CurrentUser.Id || !(message is IUserMessage userMessage))
             {
                 return;
@@ -259,78 +149,19 @@ namespace QuizBowlDiscordScoreTracker
             // Some commands may need to be taken in DM channels. Everything for handling buzzes and scoring should be
             // on the main channel 
             if (!(userMessage.Channel is ITextChannel channel &&
-                this.gameStateManager.TryGet(channel.Id, out GameState state)))
+                this.gameStateManager.TryGet(channel.Id, out GameState state) &&
+                userMessage.Author is IGuildUser guildUser))
             {
                 return;
             }
 
-            if (state.ReaderId == message.Author.Id)
+            bool buzzScored = await this.messageHandler.TryScoreBuzz(state, guildUser, channel, message.Content);
+            if (buzzScored)
             {
-                if (int.TryParse(message.Content, out int points))
-                {
-                    // Go back to only accepting -5/0/10/15/20, since we need to track splits now
-                    switch (points)
-                    {
-                        case -5:
-                        case 0:
-                        case 10:
-                        case 15:
-                        case 20:
-                            state.ScorePlayer(points);
-                            await this.PromptNextPlayerAsync(state, channel);
-                            if (points > 0)
-                            {
-                                await channel.SendMessageAsync($"**TU {state.PhaseNumber}**");
-                            }
-
-                            return;
-                        default:
-                            break;
-                    }
-                }
-                else if (message.Content.Trim() == "no penalty")
-                {
-                    state.ScorePlayer(0);
-                    await this.PromptNextPlayerAsync(state, channel);
-                    return;
-                }
-            }
-
-            // Player has buzzed in
-            string playerDisplayName = userMessage.Author is IGuildUser guildUser ?
-                guildUser.Nickname ?? guildUser.Username :
-                userMessage.Author.Username;
-            if (this.IsBuzz(message.Content) && state.AddPlayer(message.Author.Id, playerDisplayName))
-            {
-                if (state.TryGetNextPlayer(out ulong nextPlayerId) && nextPlayerId == message.Author.Id)
-                {
-                    await this.PromptNextPlayerAsync(state, channel);
-                }
-
                 return;
             }
 
-            // Player has withdrawn
-            if (message.Content.Equals("wd", StringComparison.CurrentCultureIgnoreCase) &&
-                state.WithdrawPlayer(message.Author.Id))
-            {
-                if (state.TryGetNextPlayer(out ulong nextPlayerId))
-                {
-                    // If the player withdrawing is at the top of the queue, prompt the next player
-                    if (nextPlayerId == message.Author.Id)
-                    {
-                        await this.PromptNextPlayerAsync(state, channel);
-                    }
-                }
-                else
-                {
-                    // If there are no players in the queue, have the bot recognize the withdrawl
-                    IGuildUser messageUser = await channel.Guild.GetUserAsync(message.Author.Id);
-                    await message.Channel.SendMessageAsync($"{messageUser.Mention} has withdrawn.");
-                }
-
-                return;
-            }
+            await this.messageHandler.HandlePlayerMessage(state, guildUser, channel, message.Content);
         }
 
         private Task OnLogAsync(LogMessage logMessage)
@@ -424,27 +255,6 @@ namespace QuizBowlDiscordScoreTracker
             }
 
             return Task.CompletedTask;
-        }
-
-        private bool IsBuzz(string buzzText)
-        {
-            return BuzzRegex.IsMatch(buzzText) || this.buzzEmojisRegex.Any(regex => regex.IsMatch(buzzText));
-        }
-
-        private async Task UnmuteReaderAfterDelayAsync(IVoiceChannel voiceChannel, IGuildUser reader)
-        {
-            await Task.Delay(this.options.CurrentValue.MuteDelayMs);
-
-            // Make sure the reader didn't mute themselves or leave the voice channel
-            if (!reader.IsSelfMuted && reader.VoiceChannel?.Id == voiceChannel.Id)
-            {
-                await reader.ModifyAsync(properties => properties.Mute = false);
-            }
-        }
-
-        private static string GroupFromChannel(ITextChannel channel)
-        {
-            return channel.Id.ToString(CultureInfo.InvariantCulture);
         }
     }
 }

--- a/QuizBowlDiscordScoreTracker/Commands/ReaderCommands.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/ReaderCommands.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
+using QuizBowlDiscordScoreTracker.Database;
 
 namespace QuizBowlDiscordScoreTracker.Commands
 {
@@ -8,12 +9,15 @@ namespace QuizBowlDiscordScoreTracker.Commands
     [RequireContext(ContextType.Guild)]
     public class ReaderCommands : ModuleBase
     {
-        public ReaderCommands(GameStateManager manager)
+        public ReaderCommands(GameStateManager manager, IDatabaseActionFactory dbActionFactory)
         {
             this.Manager = manager;
+            this.DatabaseActionFactory = dbActionFactory;
         }
 
         private GameStateManager Manager { get; }
+
+        private IDatabaseActionFactory DatabaseActionFactory { get; }
 
         [Command("setnewreader")]
         [Summary("Set another user as the reader.")]
@@ -60,7 +64,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
         private ReaderCommandHandler GetHandler()
         {
             // this.Context is null in the constructor, so create the handler in this method
-            return new ReaderCommandHandler(this.Context, this.Manager);
+            return new ReaderCommandHandler(this.Context, this.Manager, this.DatabaseActionFactory);
         }
     }
 }

--- a/QuizBowlDiscordScoreTracker/IGuildUserExtensionscs.cs
+++ b/QuizBowlDiscordScoreTracker/IGuildUserExtensionscs.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using QuizBowlDiscordScoreTracker.Database;
+
+namespace QuizBowlDiscordScoreTracker
+{
+    public static class IGuildUserExtensionscs
+    {
+        // I looked into the performance of this method, tosee if we should cache the team role prefix or the roles.
+        // There's a cold-start cost of about 20-25 ms on the first buzz (including adding them to the queue), and
+        // afterwards it's <10ms, while prompting takes ~150-200 ms, so it's not worth speeding this part up yet
+        public static async Task<ulong?> GetTeamId(this IGuildUser user, IDatabaseActionFactory dbActionFactory)
+        {
+            if (user == null)
+            {
+                return null;
+            }
+
+            Verify.IsNotNull(dbActionFactory, nameof(dbActionFactory));
+
+            string teamRolePrefix = null;
+            using (DatabaseAction action = dbActionFactory.Create())
+            {
+                teamRolePrefix = await action.GetTeamRolePrefixAsync(user.GuildId);
+            }
+
+            if (teamRolePrefix == null)
+            {
+                return null;
+            }
+
+            // TODO: What should we do if the user has multiple roles with the prefix? For now we'll just always take
+            // the first one
+            IEnumerable<IRole> matchingRoles = user.Guild.Roles
+                .Where(role => role.Name.StartsWith(teamRolePrefix, StringComparison.InvariantCultureIgnoreCase))
+                .Join(user.RoleIds, role => role.Id, id => id, (role, id) => role);
+            return matchingRoles.FirstOrDefault()?.Id;
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTracker/IMessageChannelExtensions.cs
+++ b/QuizBowlDiscordScoreTracker/IMessageChannelExtensions.cs
@@ -7,14 +7,6 @@ namespace QuizBowlDiscordScoreTracker
 {
     public static class IMessageChannelExtensions
     {
-        private const int MaxFieldsInEmbed = 20;
-        private const int MaxEmbedLength = 6000;
-
-        // We enumerate through each field to create an list of EmbedFieldBuidlers. Then we can do both
-        // the item limits and item length limits while iterating through that list, since we can access the index.
-        // I tried just doing it inline when going through the collection, but the logic for handling edge cases is
-        // messier.
-
         /// <summary>
         /// Sends an embed with fields for each item in the collection. If the number of items is greater than Discord's
         /// embed field limit, it splits up the message into multiple embeds.
@@ -54,12 +46,12 @@ namespace QuizBowlDiscordScoreTracker
                 EmbedBuilder embedBuilder = createEmbedBuilder();
                 int embedLength = 0;
 
-                while (embedBuilder.Fields.Count < MaxFieldsInEmbed && fieldIndex < fields.Count)
+                while (embedBuilder.Fields.Count < EmbedBuilder.MaxFieldCount && fieldIndex < fields.Count)
                 {
                     EmbedFieldBuilder field = fields[fieldIndex];
                     int fieldLength = GetEmbedFieldLength(field);
 
-                    if (fieldLength > MaxEmbedLength)
+                    if (fieldLength > EmbedBuilder.MaxEmbedLength)
                     {
                         // We will never be able to add this embed. Fail.
                         throw new ArgumentException(
@@ -67,7 +59,7 @@ namespace QuizBowlDiscordScoreTracker
                     }
 
                     embedLength += fieldLength;
-                    if (embedLength >= MaxEmbedLength)
+                    if (embedLength >= EmbedBuilder.MaxEmbedLength)
                     {
                         // This field would push us over the limit, so sotp for now.
                         break;

--- a/QuizBowlDiscordScoreTracker/MessageHandler.cs
+++ b/QuizBowlDiscordScoreTracker/MessageHandler.cs
@@ -1,0 +1,263 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Net;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
+using QuizBowlDiscordScoreTracker.Database;
+using QuizBowlDiscordScoreTracker.Web;
+using Serilog;
+
+namespace QuizBowlDiscordScoreTracker
+{
+    public class MessageHandler
+    {
+        private static readonly Regex BuzzRegex = new Regex(
+            "^\\s*bu?z+\\s*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex WithdrawRegex = new Regex(
+            "^\\s*wd\\s*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public MessageHandler(
+            IOptionsMonitor<BotConfiguration> options,
+            IDatabaseActionFactory dbActionFactory,
+            IHubContext<MonitorHub> hubContext,
+            ILogger logger)
+        {
+            Verify.IsNotNull(options, nameof(options));
+
+            this.Options = options;
+            this.DatabaseActionFactory = dbActionFactory;
+            this.HubContext = hubContext;
+            this.Logger = logger;
+
+            // TODO: Rewrite this so that
+            // #1: buzz emojis are server-dependent, since emojis are
+            // #2: This can be updated if the config file is refreshed.
+            // Alternatively, this should be a guild-dependent setting
+            this.BuzzEmojisRegex = BuildBuzzEmojiRegexes(options.CurrentValue);
+        }
+
+        private IEnumerable<Regex> BuzzEmojisRegex { get; }
+
+        private IDatabaseActionFactory DatabaseActionFactory { get; }
+
+        private IHubContext<MonitorHub> HubContext { get; }
+
+        private ILogger Logger { get; }
+
+        private IOptionsMonitor<BotConfiguration> Options { get; }
+
+        // TODO: Investigate if it makes sense to move the logic for deciding if we have a command here
+
+        public async Task HandlePlayerMessage(
+            GameState state, IGuildUser messageAuthor, ITextChannel channel, string messageContent)
+        {
+            Verify.IsNotNull(state, nameof(state));
+            Verify.IsNotNull(messageAuthor, nameof(messageAuthor));
+            Verify.IsNotNull(channel, nameof(channel));
+            Verify.IsNotNull(messageContent, nameof(messageContent));
+
+            // Player has buzzed in
+            string playerDisplayName = messageAuthor.Nickname ?? messageAuthor.Username;
+            ulong? teamId = await messageAuthor.GetTeamId(this.DatabaseActionFactory);
+            ulong nextPlayerId;
+
+            if (this.IsBuzz(messageContent) && state.AddPlayer(messageAuthor.Id, playerDisplayName, teamId))
+            {
+                if (state.TryGetNextPlayer(out nextPlayerId) && nextPlayerId == messageAuthor.Id)
+                {
+                    await this.PromptNextPlayerAsync(state, channel);
+                }
+
+                return;
+            }
+
+            // See if the player has withdrawn. We want to check if the author is at the top of the queue to see if we
+            // want to send a message about the withdrawl
+            if (WithdrawRegex.IsMatch(messageContent) &&
+                state.TryGetNextPlayer(out nextPlayerId) &&
+                state.WithdrawPlayer(messageAuthor.Id, teamId) &&
+                nextPlayerId == messageAuthor.Id)
+            {
+                if (state.TryGetNextPlayer(out _))
+                {
+                    // There's another player, so prompt them
+                    await this.PromptNextPlayerAsync(state, channel);
+                }
+                else
+                {
+                    // If there are no players in the queue, have the bot recognize the withdrawl
+                    IGuildUser messageUser = await channel.Guild.GetUserAsync(messageAuthor.Id);
+                    await channel.SendMessageAsync($"{messageUser.Mention} has withdrawn.");
+                }
+            }
+        }
+
+        public async Task<bool> TryScoreBuzz(
+            GameState state, IGuildUser messageAuthor, ITextChannel channel, string messageContent)
+        {
+            Verify.IsNotNull(state, nameof(state));
+            Verify.IsNotNull(messageAuthor, nameof(messageAuthor));
+            Verify.IsNotNull(channel, nameof(channel));
+            Verify.IsNotNull(messageContent, nameof(messageContent));
+
+            if (state.ReaderId != messageAuthor.Id || !state.TryGetNextPlayer(out _))
+            {
+                return false;
+            }
+
+            if (int.TryParse(messageContent, out int points))
+            {
+                // Go back to only accepting -5/0/10/15/20, since we need to track splits now
+                switch (points)
+                {
+                    case -5:
+                    case 0:
+                    case 10:
+                    case 15:
+                    case 20:
+                        state.ScorePlayer(points);
+                        await this.PromptNextPlayerAsync(state, channel);
+                        if (points > 0)
+                        {
+                            await channel.SendMessageAsync($"**TU {state.PhaseNumber}**");
+                        }
+
+                        return true;
+                    default:
+                        break;
+                }
+            }
+            else if (messageContent.Trim() == "no penalty")
+            {
+                state.ScorePlayer(0);
+                await this.PromptNextPlayerAsync(state, channel);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<Regex> BuildBuzzEmojiRegexes(BotConfiguration options)
+        {
+            if (options.BuzzEmojis == null)
+            {
+                return Array.Empty<Regex>();
+            }
+
+            List<Regex> result = new List<Regex>();
+            StringBuilder builder = new StringBuilder();
+            foreach (string buzzEmoji in options.BuzzEmojis)
+            {
+                builder.Append("^<");
+                builder.Append(buzzEmoji);
+                builder.Append("\\d+>$");
+                Regex regex = new Regex(builder.ToString());
+                result.Add(regex);
+                builder.Clear();
+            }
+
+            return result;
+        }
+
+        private static string GroupFromChannel(ITextChannel channel)
+        {
+            return channel.Id.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private bool IsBuzz(string buzzText)
+        {
+            return BuzzRegex.IsMatch(buzzText) || this.BuzzEmojisRegex.Any(regex => regex.IsMatch(buzzText));
+        }
+
+        private async Task<Tuple<IVoiceChannel, IGuildUser>> MuteReader(ITextChannel textChannel, ulong? readerId)
+        {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+            ulong? voiceChannelId = null;
+            using (DatabaseAction action = this.DatabaseActionFactory.Create())
+            {
+                voiceChannelId = await action.GetPairedVoiceChannelIdOrNullAsync(textChannel.Id);
+            }
+
+            stopwatch.Stop();
+            this.Logger.Verbose($"Time to get paired channel: {stopwatch.ElapsedMilliseconds} ms");
+
+            if (voiceChannelId == null)
+            {
+                return null;
+            }
+
+            IVoiceChannel voiceChannel = await textChannel.Guild.GetVoiceChannelAsync(voiceChannelId.Value);
+            if (voiceChannel == null)
+            {
+                return null;
+            }
+
+            IGuildUser reader = await textChannel.Guild.GetUserAsync(readerId.Value);
+            try
+            {
+                // Make sure the reader didn't mute themselves or leave the voice channel
+                if (!reader.IsSelfMuted && reader.VoiceChannel?.Id == voiceChannel.Id)
+                {
+                    await reader.ModifyAsync(properties => properties.Mute = true);
+                }
+            }
+            catch (HttpException ex)
+            {
+                if (ex.HttpCode == System.Net.HttpStatusCode.Forbidden)
+                {
+                    this.Logger.Error(
+                        $"Couldn't deafen reader because bot doesn't have Mute permission in guild '{voiceChannel.Guild.Name}'");
+                }
+
+                return null;
+            }
+
+            return new Tuple<IVoiceChannel, IGuildUser>(voiceChannel, reader);
+        }
+
+        private async Task PromptNextPlayerAsync(GameState state, ITextChannel textChannel)
+        {
+            if (!state.TryGetNextPlayer(out ulong userId))
+            {
+                await this.HubContext.Clients.Group(GroupFromChannel(textChannel)).SendAsync("Clear");
+                return;
+            }
+
+            IGuildUser user = await textChannel.Guild.GetUserAsync(userId);
+            Task<Tuple<IVoiceChannel, IGuildUser>> getVoiceChannelReaderPair = this.MuteReader(
+                textChannel, state.ReaderId);
+            Task sendMessage = textChannel.SendMessageAsync(user.Mention);
+            Task alertWebSocket = this.HubContext.Clients.Group(GroupFromChannel(textChannel))
+                .SendAsync("PlayerBuzz", user.Nickname ?? user.Username);
+            await Task.WhenAll(getVoiceChannelReaderPair, sendMessage, alertWebSocket);
+
+            Tuple<IVoiceChannel, IGuildUser> voiceChannelReaderPair = getVoiceChannelReaderPair.Result;
+            if (voiceChannelReaderPair != null)
+            {
+                // We want to run this on a separate thread and not block the event handler
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                Task.Run(() => this.UnmuteReaderAfterDelayAsync(voiceChannelReaderPair.Item1, voiceChannelReaderPair.Item2));
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            }
+        }
+
+        private async Task UnmuteReaderAfterDelayAsync(IVoiceChannel voiceChannel, IGuildUser reader)
+        {
+            await Task.Delay(this.Options.CurrentValue.MuteDelayMs);
+
+            // Make sure the reader didn't mute themselves or leave the voice channel
+            if (!reader.IsSelfMuted && reader.VoiceChannel?.Id == voiceChannel.Id)
+            {
+                await reader.ModifyAsync(properties => properties.Mute = false);
+            }
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTracker/PlayerTeamPair.cs
+++ b/QuizBowlDiscordScoreTracker/PlayerTeamPair.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace QuizBowlDiscordScoreTracker
+{
+    public class PlayerTeamPair : IEquatable<PlayerTeamPair>
+    {
+        /// <summary>
+        /// A pair representing a player's ID and team. The player and team IDs should be different if the player is on
+        /// a team.
+        /// </summary>
+        /// <param name="playerId"></param>
+        /// <param name="teamId"></param>
+        public PlayerTeamPair(ulong playerId, ulong? teamId)
+        {
+            this.PlayerId = playerId;
+            this.TeamId = teamId ?? playerId;
+        }
+
+        public bool IsOnTeam => this.PlayerId != this.TeamId;
+
+        public ulong PlayerId { get; private set; }
+
+        public ulong TeamId { get; private set; }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is PlayerTeamPair other))
+            {
+                return false;
+            }
+
+            return this.Equals(other);
+        }
+
+        public bool Equals([AllowNull] PlayerTeamPair other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.PlayerId == this.PlayerId && other.TeamId == this.TeamId;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.PlayerId.GetHashCode() ^ this.TeamId.GetHashCode();
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Program.cs
+++ b/QuizBowlDiscordScoreTracker/Program.cs
@@ -77,7 +77,8 @@ namespace QuizBowlDiscordScoreTracker
                         .WriteTo.File(
                             Path.Combine("logs", "bot.log"),
                             fileSizeLimitBytes: maxLogfileSize,
-                            retainedFileCountLimit: 10);
+                            rollingInterval: RollingInterval.Month,
+                            retainedFileCountLimit: 6);
                     Log.Logger = loggerConfiguration.CreateLogger();
                 })
                 .UseConsoleLifetime()

--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Company />
     <Product>Quiz Bowl Discord Score Tracker</Product>
@@ -29,7 +29,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.8" />
     <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
   </ItemGroup>

--- a/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Discord;
 using Discord.Commands;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using QuizBowlDiscordScoreTracker.Commands;
 using QuizBowlDiscordScoreTracker.Database;
 
@@ -221,9 +223,24 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 DefaultIds,
                 DefaultGuildId,
                 DefaultChannelId,
-                voiceChannelId,
-                voiceChannelName,
                 DefaultReaderId,
+                (mockGuild, textChannel) =>
+                {
+                    Mock<IVoiceChannel> mockVoiceChannel = new Mock<IVoiceChannel>();
+                    mockVoiceChannel.Setup(voiceChannel => voiceChannel.Id).Returns(voiceChannelId);
+                    mockVoiceChannel.Setup(voiceChannel => voiceChannel.Name).Returns(voiceChannelName);
+                    mockGuild
+                        .Setup(guild => guild.GetVoiceChannelAsync(It.IsAny<ulong>(), It.IsAny<CacheMode>(), It.IsAny<RequestOptions>()))
+                        .Returns(Task.FromResult(mockVoiceChannel.Object));
+
+                    List<IVoiceChannel> voiceChannels = new List<IVoiceChannel>()
+                    {
+                        mockVoiceChannel.Object
+                    };
+                    mockGuild
+                        .Setup(guild => guild.GetVoiceChannelsAsync(It.IsAny<CacheMode>(), It.IsAny<RequestOptions>()))
+                        .Returns(Task.FromResult<IReadOnlyCollection<IVoiceChannel>>(voiceChannels));
+                },
                 out guildTextChannel);
             IDatabaseActionFactory dbActionFactory = CommandMocks.CreateDatabaseActionFactory(
                 this.botConfigurationfactory);

--- a/QuizBowlDiscordScoreTrackerUnitTests/CommandMocks.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/CommandMocks.cs
@@ -4,10 +4,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Options;
 using Moq;
 using QuizBowlDiscordScoreTracker;
 using QuizBowlDiscordScoreTracker.Database;
+using QuizBowlDiscordScoreTracker.Web;
 
 namespace QuizBowlDiscordScoreTrackerUnitTests
 {
@@ -15,22 +17,21 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
     // mocks/values we'd want
     public static class CommandMocks
     {
-
         public static ICommandContext CreateCommandContext(
             MessageStore messageStore,
             HashSet<ulong> existingUserIds,
             ulong guildId,
             ulong messageChannelId,
-            ulong userId)
+            ulong userId,
+            Action<Mock<IGuild>, IGuildTextChannel> updateMockGuild = null)
         {
             return CreateCommandContext(
                 messageStore,
                 existingUserIds,
                 guildId,
                 messageChannelId,
-                voiceChannelId: 7777,
-                voiceChannelName: "Voice",
                 userId: userId,
+                updateMockGuild: updateMockGuild,
                 out _);
         }
 
@@ -39,13 +40,170 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
              HashSet<ulong> existingUserIds,
              ulong guildId,
              ulong messageChannelId,
-             ulong voiceChannelId,
-             string voiceChannelName,
              ulong userId,
+             Action<Mock<IGuild>, IGuildTextChannel> updateMockGuild,
              out IGuildTextChannel guildTextChannel)
         {
             Mock<ICommandContext> mockCommandContext = new Mock<ICommandContext>();
+            IGuild guild = CreateGuild(
+                messageStore,
+                existingUserIds,
+                guildId,
+                messageChannelId,
+                updateMockGuild,
+                null,
+                out guildTextChannel);
 
+            mockCommandContext
+                .Setup(context => context.User)
+                .Returns(CreateGuildUser(userId));
+            mockCommandContext
+                .Setup(context => context.Channel)
+                .Returns(guildTextChannel);
+            mockCommandContext
+                .Setup(context => context.Guild)
+                .Returns(guild);
+
+            return mockCommandContext.Object;
+        }
+
+        public static IGuild CreateGuild(
+           MessageStore messageStore,
+           HashSet<ulong> existingUserIds,
+            ulong guildId,
+            ulong messageChannelId,
+            Action<Mock<IGuild>, IGuildTextChannel> updateMockGuild,
+            Action<Mock<IGuildTextChannel>> updateMockTextChannel,
+            out IGuildTextChannel channel)
+        {
+            Mock<IGuild> mockGuild = new Mock<IGuild>();
+            mockGuild
+                .Setup(guild => guild.GetUserAsync(It.IsAny<ulong>(), It.IsAny<CacheMode>(), It.IsAny<RequestOptions>()))
+                .Returns<ulong, CacheMode, RequestOptions>((id, cacheMode, requestOptions) =>
+                {
+                    if (existingUserIds?.Contains(id) == true)
+                    {
+                        return Task.FromResult(CreateGuildUser(id));
+                    }
+
+                    return Task.FromResult<IGuildUser>(null);
+                });
+            mockGuild.Setup(guild => guild.Id).Returns(guildId);
+
+            Mock<IGuildUser> mockBotUser = new Mock<IGuildUser>();
+            mockBotUser
+                .Setup(user => user.GetPermissions(It.IsAny<IGuildChannel>()))
+                .Returns(new ChannelPermissions(viewChannel: true, sendMessages: true, embedLinks: true));
+            mockGuild
+                .Setup(guild => guild.GetCurrentUserAsync(It.IsAny<CacheMode>(), It.IsAny<RequestOptions>()))
+                .Returns(Task.FromResult(mockBotUser.Object));
+
+            IGuild guild = mockGuild.Object;
+            channel = CreateGuildTextChannel(messageStore, guild, messageChannelId, updateMockTextChannel);
+
+            updateMockGuild?.Invoke(mockGuild, channel);
+            return guild;
+        }
+
+        public static IGuildUser CreateGuildUser(ulong id, Action<Mock<IGuildUser>> updateMock = null)
+        {
+            Mock<IGuildUser> mockUser = new Mock<IGuildUser>();
+            mockUser
+                .Setup(user => user.Id)
+                .Returns(id);
+            mockUser
+                .Setup(user => user.Mention)
+                .Returns($"@User_{id}");
+            mockUser
+                .Setup(user => user.Username)
+                .Returns($"User_{id}");
+
+            updateMock?.Invoke(mockUser);
+            return mockUser.Object;
+        }
+
+        public static IOptionsMonitor<BotConfiguration> CreateConfigurationOptionsMonitor()
+        {
+            Mock<IOptionsMonitor<BotConfiguration>> mockOptionsMonitor = new Mock<IOptionsMonitor<BotConfiguration>>();
+            Mock<BotConfiguration> mockConfiguration = new Mock<BotConfiguration>();
+            mockConfiguration
+                .Setup(config => config.DatabaseDataSource)
+                .Returns("memory&cached=true");
+
+            // We can't set the WebURL directly without making it virtual or adding an interface for BotConfiguration
+            mockOptionsMonitor.Setup(options => options.CurrentValue).Returns(mockConfiguration.Object);
+            return mockOptionsMonitor.Object;
+        }
+
+        public static IDatabaseActionFactory CreateDatabaseActionFactory(InMemoryBotConfigurationContextFactory factory)
+        {
+            Mock<IDatabaseActionFactory> mockDbActionFactory = new Mock<IDatabaseActionFactory>();
+            mockDbActionFactory
+                .Setup(dbActionFactory => dbActionFactory.Create())
+                .Returns(() => new DatabaseAction(factory.Create()));
+            return mockDbActionFactory.Object;
+        }
+
+        public static IHubContext<MonitorHub> CreateHubContext()
+        {
+            Mock<IHubContext<MonitorHub>> mockHubContext = new Mock<IHubContext<MonitorHub>>();
+            Mock<IHubClients> mockHubClients = new Mock<IHubClients>();
+            Mock<IClientProxy> mockClientProxy = new Mock<IClientProxy>();
+
+            // TODO: We should try to log the messages, but we can't intercept the SendAsync call since it's an
+            // extension method, so we can't see what is being sent. One suggestion is to wrap the static extension
+            // call in another method/interface, which we could then mock
+
+            // TODO: We should log these messages somewhere (MessageStore?)
+            ////mockClientProxy
+            ////    .Setup(clientProxy => clientProxy.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            ////    .Returns(Task.CompletedTask);
+
+            mockHubClients
+                .Setup(groupManager => groupManager.Group(It.IsAny<string>()))
+                .Returns(mockClientProxy.Object);
+
+            mockHubContext
+                .Setup(hubContext => hubContext.Clients)
+                .Returns(mockHubClients.Object);
+
+            return mockHubContext.Object;
+        }
+
+        public static string GetMockEmbedText(IEmbed embed)
+        {
+            if (embed == null)
+            {
+                throw new ArgumentNullException(nameof(embed));
+            }
+
+            return GetMockEmbedText(
+                embed.Title, embed.Description, embed.Fields.ToDictionary(field => field.Name, field => field.Value));
+        }
+
+        private static IGuildTextChannel CreateGuildTextChannel(
+            MessageStore messageStore,
+            IGuild guild,
+            ulong messageChannelId,
+            Action<Mock<IGuildTextChannel>> updateMock = null)
+        {
+            Mock<IGuildTextChannel> mockMessageChannel =
+                CreateMockGuildTextChannel(messageStore, messageChannelId, updateMock);
+
+            mockMessageChannel
+                .Setup(channel => channel.Guild)
+                .Returns(guild);
+
+            // Okay to invoke twice?
+            updateMock?.Invoke(mockMessageChannel);
+            return mockMessageChannel.Object;
+        }
+
+        private static Mock<IGuildTextChannel> CreateMockGuildTextChannel(
+            MessageStore messageStore,
+            ulong messageChannelId,
+            Action<Mock<IGuildTextChannel>> updateMock = null)
+        {
             Mock<IGuildTextChannel> mockMessageChannel = new Mock<IGuildTextChannel>();
             Mock<IUserMessage> mockUserMessage = new Mock<IUserMessage>();
             mockMessageChannel
@@ -69,109 +227,8 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 .Setup(channel => channel.Name)
                 .Returns("gameChannel");
 
-            Mock<IGuild> mockGuild = new Mock<IGuild>();
-            mockGuild
-                .Setup(guild => guild.GetUserAsync(It.IsAny<ulong>(), It.IsAny<CacheMode>(), It.IsAny<RequestOptions>()))
-                .Returns<ulong, CacheMode, RequestOptions>((id, cacheMode, requestOptions) =>
-                {
-                    if (existingUserIds?.Contains(id) == true)
-                    {
-                        return Task.FromResult(CreateGuildUser(id));
-                    }
-
-                    return Task.FromResult<IGuildUser>(null);
-                });
-            mockGuild.Setup(guild => guild.Id).Returns(guildId);
-
-            Mock<IVoiceChannel> mockVoiceChannel = new Mock<IVoiceChannel>();
-            mockVoiceChannel.Setup(voiceChannel => voiceChannel.Id).Returns(voiceChannelId);
-            mockVoiceChannel.Setup(voiceChannel => voiceChannel.Name).Returns(voiceChannelName);
-            mockGuild
-                .Setup(guild => guild.GetVoiceChannelAsync(It.IsAny<ulong>(), It.IsAny<CacheMode>(), It.IsAny<RequestOptions>()))
-                .Returns(Task.FromResult(mockVoiceChannel.Object));
-
-            List<IVoiceChannel> voiceChannels = new List<IVoiceChannel>()
-            {
-                mockVoiceChannel.Object
-            };
-            mockGuild
-                .Setup(guild => guild.GetVoiceChannelsAsync(It.IsAny<CacheMode>(), It.IsAny<RequestOptions>()))
-                .Returns(Task.FromResult<IReadOnlyCollection<IVoiceChannel>>(voiceChannels));
-
-            Mock<IGuildUser> mockBotUser = new Mock<IGuildUser>();
-            mockBotUser
-                .Setup(user => user.GetPermissions(It.IsAny<IGuildChannel>()))
-                .Returns(new ChannelPermissions(viewChannel: true, sendMessages: true, embedLinks: true));
-            mockGuild
-                .Setup(guild => guild.GetCurrentUserAsync(It.IsAny<CacheMode>(), It.IsAny<RequestOptions>()))
-                .Returns(Task.FromResult(mockBotUser.Object));
-
-            mockMessageChannel
-                .Setup(channel => channel.Guild)
-                .Returns(mockGuild.Object);
-
-            mockCommandContext
-                .Setup(context => context.User)
-                .Returns(CreateGuildUser(userId));
-            mockCommandContext
-                .Setup(context => context.Channel)
-                .Returns(mockMessageChannel.Object);
-            mockCommandContext
-                .Setup(context => context.Guild)
-                .Returns(mockGuild.Object);
-
-            guildTextChannel = mockMessageChannel.Object;
-            return mockCommandContext.Object;
-        }
-
-        public static IGuildUser CreateGuildUser(ulong id)
-        {
-            Mock<IGuildUser> mockUser = new Mock<IGuildUser>();
-            mockUser
-                .Setup(user => user.Id)
-                .Returns(id);
-            mockUser
-                .Setup(user => user.Mention)
-                .Returns($"@User_{id}");
-            mockUser
-                .Setup(user => user.Username)
-                .Returns($"User_{id}");
-            return mockUser.Object;
-        }
-
-        public static IOptionsMonitor<BotConfiguration> CreateConfigurationOptionsMonitor()
-        {
-            Mock<IOptionsMonitor<BotConfiguration>> mockOptionsMonitor = new Mock<IOptionsMonitor<BotConfiguration>>();
-            Mock<BotConfiguration> mockConfiguration = new Mock<BotConfiguration>();
-            mockConfiguration
-                .Setup(config => config.DatabaseDataSource)
-                .Returns("memory&cached=true");
-
-            // We can't set the WebURL directly without making it virtual or adding an interface for BotConfiguration
-            mockOptionsMonitor.Setup(options => options.CurrentValue).Returns(mockConfiguration.Object);
-            return mockOptionsMonitor.Object;
-        }
-
-        public static IDatabaseActionFactory CreateDatabaseActionFactory(InMemoryBotConfigurationContextFactory factory)
-        {
-            // TODO: See how we can dispose this correctly
-
-            Mock<IDatabaseActionFactory> mockDbActionFactory = new Mock<IDatabaseActionFactory>();
-            mockDbActionFactory
-                .Setup(dbActionFactory => dbActionFactory.Create())
-                .Returns(() => new DatabaseAction(factory.Create()));
-            return mockDbActionFactory.Object;
-        }
-
-        public static string GetMockEmbedText(IEmbed embed)
-        {
-            if (embed == null)
-            {
-                throw new ArgumentNullException(nameof(embed));
-            }
-
-            return GetMockEmbedText(
-                embed.Title, embed.Description, embed.Fields.ToDictionary(field => field.Name, field => field.Value));
+            updateMock?.Invoke(mockMessageChannel);
+            return mockMessageChannel;
         }
 
         private static string GetMockEmbedText(string title, string description, IDictionary<string, string> fields = null)

--- a/QuizBowlDiscordScoreTrackerUnitTests/MessageHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/MessageHandlerTests.cs
@@ -1,0 +1,292 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
+using Discord;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using QuizBowlDiscordScoreTracker;
+using QuizBowlDiscordScoreTracker.Database;
+using Serilog;
+
+namespace QuizBowlDiscordScoreTrackerUnitTests
+{
+    [TestClass]
+    public sealed class MessageHandlerTests : IDisposable
+    {
+        private const ulong DefaultReaderId = 1;
+        private const ulong DefaultPlayerId = 2;
+        private const ulong DefaultSecondPlayerId = 3;
+        private static readonly HashSet<ulong> DefaultIds = new HashSet<ulong>()
+        {
+            DefaultReaderId,
+            DefaultPlayerId,
+            DefaultSecondPlayerId
+        };
+
+        private const ulong DefaultGuildId = 9;
+        private const ulong DefaultChannelId = 11;
+        private const ulong DefaultVoiceChannelId = 222;
+
+        private InMemoryBotConfigurationContextFactory botConfigurationfactory;
+
+        [TestInitialize]
+        public void InitializeTest()
+        {
+            this.botConfigurationfactory = new InMemoryBotConfigurationContextFactory();
+
+            // Make sure the database is initialized before running the test
+            using (BotConfigurationContext context = this.botConfigurationfactory.Create())
+            {
+                context.Database.Migrate();
+            }
+        }
+
+        [TestCleanup]
+        public void Dispose()
+        {
+            this.botConfigurationfactory.Dispose();
+        }
+
+        [TestMethod]
+        public async Task BuzzAndNeg()
+        {
+            await this.VerifyBuzzAndScore(-5);
+        }
+        [TestMethod]
+        public async Task BuzzAndZero()
+        {
+            await this.VerifyBuzzAndScore(0);
+        }
+
+        [TestMethod]
+        public async Task BuzzAndGet()
+        {
+            await this.VerifyBuzzAndScore(10);
+        }
+
+        [TestMethod]
+        public async Task BuzzAndPower()
+        {
+            await this.VerifyBuzzAndScore(15);
+        }
+
+        [TestMethod]
+        public async Task BuzzAndSuperpower()
+        {
+            await this.VerifyBuzzAndScore(20);
+        }
+
+        [TestMethod]
+        public async Task BuzzAndNoPenalty()
+        {
+            this.CreateHandler(
+                out MessageHandler handler,
+                out GameState state,
+                out IGuildUser playerUser,
+                out IGuildUser readerUser,
+                out IGuildTextChannel channel,
+                out MessageStore messageStore);
+
+            await handler.HandlePlayerMessage(state, playerUser, channel, "buzz");
+            messageStore.VerifyChannelMessages(playerUser.Mention);
+            messageStore.Clear();
+
+            await handler.TryScoreBuzz(state, readerUser, channel, "no penalty");
+            IDictionary<PlayerTeamPair, ScoringSplitOnScoreAction> lastSplits = state.GetLastScoringSplits();
+            PlayerTeamPair pair = new PlayerTeamPair(DefaultPlayerId, null);
+            Assert.IsTrue(
+                lastSplits.TryGetValue(pair, out ScoringSplitOnScoreAction split),
+                "Couldn't get scoring split");
+            Assert.AreEqual(0, split.Split.Points, "Unexpected number of points");
+            messageStore.VerifyChannelMessages();
+        }
+
+        [TestMethod]
+        public async Task OnlyReaderCanScore()
+        {
+            this.CreateHandler(
+                out MessageHandler handler,
+                out GameState state,
+                out IGuildUser playerUser,
+                out IGuildUser readerUser,
+                out IGuildTextChannel channel,
+                out MessageStore messageStore);
+
+            state.AddPlayer(DefaultPlayerId, "Player");
+
+            bool scoredBuzz = await handler.TryScoreBuzz(state, playerUser, channel, "no penalty");
+            Assert.IsFalse(scoredBuzz, "Player shouldn't be able to give points");
+            IDictionary<PlayerTeamPair, ScoringSplitOnScoreAction> lastSplits = state.GetLastScoringSplits();
+            PlayerTeamPair pair = new PlayerTeamPair(DefaultPlayerId, null);
+            Assert.IsFalse(lastSplits.TryGetValue(pair, out _), "Scoring split shouldn't exist");
+
+            scoredBuzz = await handler.TryScoreBuzz(state, readerUser, channel, "10");
+            Assert.IsTrue(scoredBuzz, "Buzz wasn't scored");
+            lastSplits = state.GetLastScoringSplits();
+            Assert.IsTrue(
+                lastSplits.TryGetValue(pair, out ScoringSplitOnScoreAction split),
+                "Couldn't get scoring split"); ;
+            Assert.AreEqual(10, split.Split.Points, "Unexpected number of points");
+            messageStore.VerifyChannelMessages("**TU 2**");
+        }
+
+        [TestMethod]
+        public async Task PlayerAfterWithdrawnPlayerIsPrompted()
+        {
+            this.CreateHandler(
+                out MessageHandler handler,
+                out GameState state,
+                out IGuildUser firstPlayerUser,
+                out _,
+                out IGuildTextChannel channel,
+                out MessageStore messageStore);
+            IGuildUser secondPlayerUser = CommandMocks.CreateGuildUser(DefaultSecondPlayerId);
+
+            await handler.HandlePlayerMessage(state, firstPlayerUser, channel, "buzz");
+            await handler.HandlePlayerMessage(state, secondPlayerUser, channel, "buzz");
+            messageStore.VerifyChannelMessages(firstPlayerUser.Mention);
+            messageStore.Clear();
+
+            await handler.HandlePlayerMessage(state, firstPlayerUser, channel, "wd");
+            messageStore.VerifyChannelMessages(secondPlayerUser.Mention);
+
+            Assert.IsTrue(state.TryGetNextPlayer(out ulong nextPlayerId), "Couldn't get another player");
+            Assert.AreEqual(DefaultSecondPlayerId, nextPlayerId, "Unexpected user prompted");
+        }
+
+        [TestMethod]
+        public async Task NoMessageWhenNonPromptedPlayerWithdraws()
+        {
+            this.CreateHandler(
+                out MessageHandler handler,
+                out GameState state,
+                out IGuildUser firstPlayerUser,
+                out _,
+                out IGuildTextChannel channel,
+                out MessageStore messageStore);
+            IGuildUser secondPlayerUser = CommandMocks.CreateGuildUser(DefaultSecondPlayerId);
+
+            await handler.HandlePlayerMessage(state, firstPlayerUser, channel, "buzz");
+            await handler.HandlePlayerMessage(state, secondPlayerUser, channel, "buzz");
+            messageStore.VerifyChannelMessages(firstPlayerUser.Mention);
+            messageStore.Clear();
+
+            await handler.HandlePlayerMessage(state, secondPlayerUser, channel, "wd");
+            messageStore.VerifyChannelMessages();
+
+            Assert.IsTrue(state.TryGetNextPlayer(out ulong nextPlayerId), "Couldn't get another player");
+            Assert.AreEqual(DefaultPlayerId, nextPlayerId, "Unexpected user prompted");
+
+            state.ScorePlayer(0);
+            Assert.IsFalse(state.TryGetNextPlayer(out _), "Second player should've been withdrawn");
+        }
+
+        [TestMethod]
+        public async Task CanBuzzAfterWithdrawl()
+        {
+            this.CreateHandler(
+                out MessageHandler handler,
+                out GameState state,
+                out IGuildUser playerUser,
+                out _,
+                out IGuildTextChannel channel,
+                out MessageStore messageStore);
+
+            await handler.HandlePlayerMessage(state, playerUser, channel, "buzz");
+            messageStore.VerifyChannelMessages(playerUser.Mention);
+            messageStore.Clear();
+
+            await handler.HandlePlayerMessage(state, playerUser, channel, "wd");
+            messageStore.VerifyChannelMessages($"{playerUser.Mention} has withdrawn.");
+            messageStore.Clear();
+
+            await handler.HandlePlayerMessage(state, playerUser, channel, "buzz");
+            messageStore.VerifyChannelMessages(playerUser.Mention);
+
+            Assert.IsTrue(
+                state.TryGetNextPlayer(out ulong nextPlayerId),
+                "Couldn't get another player");
+            Assert.AreEqual(DefaultPlayerId, nextPlayerId, "Unexpected user prompted");
+        }
+
+        private async Task VerifyBuzzAndScore(int score)
+        {
+            this.CreateHandler(
+                out MessageHandler handler,
+                out GameState state,
+                out IGuildUser playerUser,
+                out IGuildUser readerUser,
+                out IGuildTextChannel channel,
+                out MessageStore messageStore);
+
+            await handler.HandlePlayerMessage(state, playerUser, channel, "buzz");
+            messageStore.VerifyChannelMessages(playerUser.Mention);
+            messageStore.Clear();
+
+            bool scoredBuzz = await handler.TryScoreBuzz(
+                state, readerUser, channel, score.ToString(CultureInfo.InvariantCulture));
+            Assert.IsTrue(scoredBuzz, "Buzz wasn't scored");
+            IDictionary<PlayerTeamPair, ScoringSplitOnScoreAction> lastSplits = state.GetLastScoringSplits();
+            PlayerTeamPair pair = new PlayerTeamPair(DefaultPlayerId, null);
+            Assert.IsTrue(
+                lastSplits.TryGetValue(pair, out ScoringSplitOnScoreAction split),
+                "Couldn't get scoring split");
+            Assert.AreEqual(score, split.Split.Points, "Unexpected number of points");
+
+            if (score > 0)
+            {
+                messageStore.VerifyChannelMessages("**TU 2**");
+            }
+        }
+
+        private void CreateHandler(
+            out MessageHandler handler,
+            out GameState state,
+            out IGuildUser playerUser,
+            out IGuildUser readerUser,
+            out IGuildTextChannel channel,
+            out MessageStore messageStore)
+        {
+            messageStore = new MessageStore();
+            IDatabaseActionFactory dbActionFactory = CommandMocks.CreateDatabaseActionFactory(
+                this.botConfigurationfactory);
+            IOptionsMonitor<BotConfiguration> options = CommandMocks.CreateConfigurationOptionsMonitor();
+            handler = new MessageHandler(
+                options, dbActionFactory, CommandMocks.CreateHubContext(), new Mock<ILogger>().Object);
+            state = new GameState()
+            {
+                ReaderId = DefaultReaderId
+            };
+
+            playerUser = CommandMocks.CreateGuildUser(DefaultPlayerId);
+            readerUser = CommandMocks.CreateGuildUser(DefaultReaderId);
+            CommandMocks.CreateGuild(
+                messageStore,
+                DefaultIds,
+                DefaultGuildId,
+                DefaultChannelId,
+                (mockGuild, textChannel) =>
+                {
+                    Mock<IVoiceChannel> mockVoiceChannel = new Mock<IVoiceChannel>();
+                    mockVoiceChannel.Setup(voiceChannel => voiceChannel.Id).Returns(DefaultVoiceChannelId);
+                    mockVoiceChannel.Setup(voiceChannel => voiceChannel.Name).Returns("Voice");
+                    mockGuild
+                        .Setup(guild => guild.GetVoiceChannelAsync(It.IsAny<ulong>(), It.IsAny<CacheMode>(), It.IsAny<RequestOptions>()))
+                        .Returns(Task.FromResult(mockVoiceChannel.Object));
+
+                    List<IVoiceChannel> voiceChannels = new List<IVoiceChannel>()
+                    {
+                        mockVoiceChannel.Object
+                    };
+                    mockGuild
+                        .Setup(guild => guild.GetVoiceChannelsAsync(It.IsAny<CacheMode>(), It.IsAny<RequestOptions>()))
+                        .Returns(Task.FromResult<IReadOnlyCollection<IVoiceChannel>>(voiceChannels));
+                },
+                null,
+                out channel);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
-﻿### Quiz Bowl Discord Score Tracker
+﻿# Quiz Bowl Discord Score Tracker
 This is a Discord bot which keeps track of who buzzed in, as well as each player's score.
 
-#### Instructions:
+## Usage
+
+### Adding the bot to your server:
+
+- Click [here](https://discordapp.com/oauth2/authorize?client_id=469025702885326849&scope=bot) to add the bot to your server.
+- Grant the bot the following permissions:
+  - Read Text Channels & See Voice Messages
+  - Embed Links
+  - Send Messages
+  - Mute Members
+- If you want to mute the reader when someone buzzes in, use this command to pair your packet channel with the voice channel:
+!pairChannels #packet-text-channel Voice-Channel-Name
+
+### Instructions:
 - If you want to be the reader, type in !read
 - Read questions. Buzz in with "buzz", or near equivalents like "bzz", "buzzzz", etc.
+  - If a player needs to withdraw their buzz, type in "wd"
 - When someone buzzes in, give them a score (-5, 0, 10, 15, 20). If the person gets the question wrong, the next person in the queue will be prompted.
   - If no one got the question correct, type in !next
   - If the current question is in a bad state and you need to clear all answers and the queue, type in !clear
@@ -11,8 +25,11 @@ This is a Discord bot which keeps track of who buzzed in, as well as each player
 - If the reader needs to undo their last scoring action, use !undo
 - If you want to change readers, use !setnewreader @NewReadersMention
 - When you're done reading, type !end
+- To see the list of all the commands, type !help
 
-#### Development Requirements:
+## Development
+
+### Requirements:
 - [.Net Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1)
   - If using Visual Studio, you need Visual Studio 2017.5
 - Libraries from Nuget:
@@ -25,7 +42,7 @@ This is a Discord bot which keeps track of who buzzed in, as well as each player
 - Install [Libman](https://docs.microsoft.com/en-us/aspnet/core/client-side/libman/libman-cli), and run `libman restore` in the Web directory
 - You will need to create your own Discord bot at https://discordapp.com/developers. Follow the steps around creating your bot in Discord mentioned in the "Running the bot on your own machine" section.
     
-#### Runnig the bot on your own machine
+### Runnig the bot on your own machine
 - Install [.Net Core Runtime 3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1)  
 - Unzip the release
 - Create your own config file. Use the sampleConfig.txt file as an example. Your file should be called config.txt.
@@ -34,14 +51,6 @@ This is a Discord bot which keeps track of who buzzed in, as well as each player
   - Visit this site (with your bot's client ID) to add the bot to your channel
     - https://discordapp.com/oauth2/authorize?client_id=CLIENTID&scope=bot
 - Run the .exe file
-- Grant your bot the following permissions:
-  - Read Text Channels & See Voice Messages
-  - Embed Links
-  - Send Messages
-  - Mute Members
-  
-#### Running the bot on the author's machine
-- Visit this site to add the bot to your server: https://discordapp.com/oauth2/authorize?client_id=469025702885326849&scope=bot
 - Grant your bot the following permissions:
   - Read Text Channels & See Voice Messages
   - Embed Links


### PR DESCRIPTION
- Support for teams when using server roles (with teamRolePrefix set)
- Accept whitespace around "wd"
- Fix issue where withdrawing in certain cases would break the buzz queue, requiring a !clear
- Roll over logs to a new file every month
- Bumped version to 3.2.0

Code-only
- Moved the buzz/prompting logic to its own class, and added tests for it