### PR TITLE
Merged PR 129: Fix issue where websocket failed because AddToChannel wasn't found

### DIFF
--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.2.0</Version>
+    <Version>3.2.1</Version>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Company />
     <Product>Quiz Bowl Discord Score Tracker</Product>

--- a/QuizBowlDiscordScoreTracker/Web/MonitorHub.cs
+++ b/QuizBowlDiscordScoreTracker/Web/MonitorHub.cs
@@ -5,7 +5,8 @@ namespace QuizBowlDiscordScoreTracker.Web
 {
     public class MonitorHub : Hub
     {
-        public async Task AddToChannelAsync(string channelId)
+        // Use the old name (without Async) so it's found
+        public async Task AddToChannel(string channelId)
         {
             await this.Groups.AddToGroupAsync(this.Context.ConnectionId, channelId);
 


### PR DESCRIPTION
- Fix issue where websocket failed because AddToChannel wasn't found. Removing Async from the method name in C# fixes it.
- Bump version to 3.2.1