### PR TITLE
Merged PR 131: Add bonuses, bump version to 3.4.0

### DIFF
--- a/QuizBowlDiscordScoreTracker/BonusStats.cs
+++ b/QuizBowlDiscordScoreTracker/BonusStats.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace QuizBowlDiscordScoreTracker
+{
+    public class BonusStats
+    {
+        public static readonly BonusStats Default = new BonusStats()
+        {
+            Heard = 0,
+            Total = 0
+        };
+
+        public int Heard { get; set; }
+
+        public int Total { get; set; }
+
+        // Don't show NaN, show 0 instead if no bonuses have been heard
+        public double PointsPerBonus => this.Heard == 0 ? 0 : Math.Round(((double)this.Total) / this.Heard, 2);
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Bot.cs
+++ b/QuizBowlDiscordScoreTracker/Bot.cs
@@ -43,13 +43,8 @@ namespace QuizBowlDiscordScoreTracker
 
         public Bot(IOptionsMonitor<BotConfiguration> options, IHubContext<MonitorHub> hubContext)
         {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-
             this.gameStateManager = new GameStateManager();
-            this.options = options;
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
             this.dbActionFactory = new SqliteDatabaseActionFactory(this.options.CurrentValue.DatabaseDataSource);
             this.readerRejoinedMap = new Dictionary<IGuildUser, bool>();
 
@@ -155,8 +150,8 @@ namespace QuizBowlDiscordScoreTracker
                 return;
             }
 
-            bool buzzScored = await this.messageHandler.TryScoreBuzz(state, guildUser, channel, message.Content);
-            if (buzzScored)
+            bool answersScored = await this.messageHandler.TryScore(state, guildUser, channel, message.Content);
+            if (answersScored)
             {
                 return;
             }

--- a/QuizBowlDiscordScoreTracker/Commands/AdminCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/AdminCommandHandler.cs
@@ -108,6 +108,51 @@ namespace QuizBowlDiscordScoreTracker.Commands
             await this.Context.Channel.SendMessageAsync("Prefix unset. Roles no longer determine who is on a team.");
         }
 
+        public async Task DisableBonusesAlwaysAsync()
+        {
+            using (DatabaseAction action = this.DatabaseActionFactory.Create())
+            {
+                await action.SetUseBonuses(this.Context.Guild.Id, false);
+            }
+
+            Logger.Information($"Use Bonuses set to false in guild {this.Context.Guild.Id} by user {this.Context.User.Id}");
+            await this.Context.Channel.SendMessageAsync(
+                "Scoring bonuses will no longer be required for every game in this server.");
+        }
+
+        public async Task EnableBonusesAlwaysAsync()
+        {
+            using (DatabaseAction action = this.DatabaseActionFactory.Create())
+            {
+                await action.SetUseBonuses(this.Context.Guild.Id, true);
+            }
+
+            Logger.Information($"Use Bonuses set to true in guild {this.Context.Guild.Id} by user {this.Context.User.Id}");
+            await this.Context.Channel.SendMessageAsync("Scoring bonuses is now required for every game in this server.");
+        }
+
+        public async Task GetDefaultFormatAsync()
+        {
+            bool useBonuses;
+            string teamRolePrefix;
+            using (DatabaseAction action = this.DatabaseActionFactory.Create())
+            {
+                useBonuses = await action.GetUseBonuses(this.Context.Guild.Id);
+                teamRolePrefix = await action.GetTeamRolePrefixAsync(this.Context.Guild.Id);
+            }
+
+            Logger.Information($"getFormat called in guild {this.Context.Guild.Id} by user {this.Context.User.Id}");
+            EmbedBuilder builder = new EmbedBuilder()
+            {
+                Title = "Default Format",
+                Description = "The default settings for games in this server"
+            };
+            builder.AddField("Require scoring bonuses?", useBonuses ? "Yes" : "No");
+            builder.AddField("Team role prefix?", teamRolePrefix == null ? "None set" : @$"Yes: ""{teamRolePrefix}""");
+
+            await this.Context.Channel.SendMessageAsync(embed: builder.Build());
+        }
+
         public async Task GetPairedChannelAsync([Summary("Text channel mention (#textChannelName)")] ITextChannel textChannel)
         {
             if (textChannel == null)

--- a/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
@@ -31,6 +31,20 @@ namespace QuizBowlDiscordScoreTracker.Commands
             return this.GetHandler().ClearTeamRolePrefixAsync();
         }
 
+        [Command("disableBonusesAlways")]
+        [Summary("Ensures that bonuses are never tracked in this server.")]
+        public Task DisableBonusesAsync()
+        {
+            return this.GetHandler().DisableBonusesAlwaysAsync();
+        }
+
+        [Command("enableBonusesAlways")]
+        [Summary("Makes scoring bonuses in a game required in this server.")]
+        public Task EnableBonusesAsync()
+        {
+            return this.GetHandler().EnableBonusesAlwaysAsync();
+        }
+
         [Command("getPairedChannel")]
         [Summary("Gets the name of the paired voice channel, if it exists. Only server admins can invoke this.")]
         public Task GetPairedChannelAsync([Summary("Text channel mention (#textChannelName)")] ITextChannel textChannel)
@@ -44,6 +58,13 @@ namespace QuizBowlDiscordScoreTracker.Commands
         public Task GetTeamRolePrefixAsync()
         {
             return this.GetHandler().GetTeamRolePrefixAsync();
+        }
+
+        [Command("getDefaultFormat")]
+        [Summary("Posts the default format for games in this server (such as if bonuses are used).")]
+        public Task GetDefaultFormatAsync()
+        {
+            return this.GetHandler().GetDefaultFormatAsync();
         }
 
         [Command("pairChannels")]

--- a/QuizBowlDiscordScoreTracker/Commands/ReaderCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/ReaderCommandHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
+using QuizBowlDiscordScoreTracker.Database;
 using QuizBowlDiscordScoreTracker.TeamManager;
 using Serilog;
 
@@ -10,13 +11,17 @@ namespace QuizBowlDiscordScoreTracker.Commands
     {
         private static readonly ILogger Logger = Log.ForContext(typeof(ReaderCommandHandler));
 
-        public ReaderCommandHandler(ICommandContext context, GameStateManager manager)
+        public ReaderCommandHandler(
+            ICommandContext context, GameStateManager manager, IDatabaseActionFactory dbActionFactory)
         {
             this.Context = context;
             this.Manager = manager;
+            this.DatabaseActionFactory = dbActionFactory;
         }
 
         private ICommandContext Context { get; }
+
+        private IDatabaseActionFactory DatabaseActionFactory { get; }
 
         private GameStateManager Manager { get; }
 
@@ -87,6 +92,59 @@ namespace QuizBowlDiscordScoreTracker.Commands
                 $@"Player ""{playerName}"" removed from their team.");
         }
 
+        public async Task DisableBonusesAsync()
+        {
+            if (!this.Manager.TryGet(this.Context.Channel.Id, out GameState game))
+            {
+                // This command only works during a game
+                return;
+            }
+            else if (game.Format.HighestPhaseIndexWithBonus < 0)
+            {
+                await this.Context.Channel.SendMessageAsync("Bonuses are already untracked.");
+                return;
+            }
+
+            bool alwaysUseBonuses;
+            using (DatabaseAction action = this.DatabaseActionFactory.Create())
+            {
+                alwaysUseBonuses = await action.GetUseBonuses(this.Context.Guild.Id);
+            }
+
+            if (alwaysUseBonuses)
+            {
+                await this.Context.Channel.SendMessageAsync(
+                    "Bonuses are always tracked in this server. Run !disableBonusesAlways and restart the game to stop tracking bonuses.");
+                return;
+            }
+
+            // TODO: We should look into cloning the format and changing the HighestPhaseIndexWithBonus field. This
+            // would require another argument for the enable command, though, since it requires a number
+            game.Format = Format.TossupShootout;
+            await this.Context.Channel.SendMessageAsync(
+                "Bonuses are no longer being tracked. Scores for the current question have been cleared.");
+        }
+
+        public async Task EnableBonusesAsync()
+        {
+            if (!this.Manager.TryGet(this.Context.Channel.Id, out GameState game))
+            {
+                // This command only works during a game
+                return;
+            }
+            else if (game.Format.HighestPhaseIndexWithBonus >= 0)
+            {
+                await this.Context.Channel.SendMessageAsync("Bonuses are already tracked.");
+                return;
+            }
+
+            // TODO: We should look into cloning the format and changing the HighestPhaseIndexWithBonus field. This
+            // would require an argument for how many bonuses to read
+            game.Format = Format.TossupBonusesShootout;
+            await this.Context.Channel.SendMessageAsync(
+                "Bonuses are now being tracked. Scores for the current question have been cleared.");
+        }
+
         public async Task SetNewReaderAsync(IGuildUser newReader)
         {
             if (newReader != null && this.Manager.TryGet(this.Context.Channel.Id, out GameState game))
@@ -143,6 +201,10 @@ namespace QuizBowlDiscordScoreTracker.Commands
             {
                 return;
             }
+            else if (game.PhaseNumber >= GameState.MaximumPhasesCount)
+            {
+                await this.Context.Channel.SendMessageAsync($"Reached the limit for games ({GameState.MaximumPhasesCount} questions)");
+            }
 
             game.NextQuestion();
 
@@ -153,11 +215,18 @@ namespace QuizBowlDiscordScoreTracker.Commands
 
         public async Task UndoAsync()
         {
-            if (!(this.Manager.TryGet(this.Context.Channel.Id, out GameState game) && game.Undo(out ulong userId)))
+            if (!(this.Manager.TryGet(this.Context.Channel.Id, out GameState game) && game.Undo(out ulong? nextUserId)))
             {
                 return;
             }
 
+            if (nextUserId == null && game.CurrentStage == PhaseStage.Bonus)
+            {
+                await this.Context.Channel.SendMessageAsync($"**Bonus for TU {game.PhaseNumber}**");
+                return;
+            }
+
+            ulong userId = nextUserId.Value;
             IGuildUser user = await this.Context.Guild.GetUserAsync(userId);
             string name;
             string message;
@@ -174,7 +243,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
                 string nextPlayerMention = null;
                 while (game.TryGetNextPlayer(out ulong nextPlayerId))
                 {
-                    IGuildUser nextPlayerUser = await this.Context.Guild.GetUserAsync(userId);
+                    IGuildUser nextPlayerUser = await this.Context.Guild.GetUserAsync(nextPlayerId);
                     if (nextPlayerUser != null)
                     {
                         nextPlayerMention = nextPlayerUser.Mention;
@@ -186,7 +255,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
                 }
 
                 message = nextPlayerMention != null ?
-                    $"Undid scoring for {name}. {nextPlayerMention}. your answer?" :
+                    $"Undid scoring for {name}. {nextPlayerMention}, your answer?" :
                     $"Undid scoring for {name}.";
             }
             else

--- a/QuizBowlDiscordScoreTracker/Commands/ReaderCommands.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/ReaderCommands.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
+using QuizBowlDiscordScoreTracker.Database;
 
 namespace QuizBowlDiscordScoreTracker.Commands
 {
@@ -8,10 +9,13 @@ namespace QuizBowlDiscordScoreTracker.Commands
     [RequireContext(ContextType.Guild)]
     public class ReaderCommands : ModuleBase
     {
-        public ReaderCommands(GameStateManager manager)
+        public ReaderCommands(GameStateManager manager, IDatabaseActionFactory dbActionFactory)
         {
             this.Manager = manager;
+            this.DatabaseActionFactory = dbActionFactory;
         }
+
+        private IDatabaseActionFactory DatabaseActionFactory { get; }
 
         private GameStateManager Manager { get; }
 
@@ -36,6 +40,20 @@ namespace QuizBowlDiscordScoreTracker.Commands
             return this.GetHandler().RemovePlayerAsync(player);
         }
 
+        [Command("disableBonuses")]
+        [Summary("Makes the current game track only tossups from now on. This command will reset the current cycle (like !clear)")]
+        public Task DisableBonusesAsync()
+        {
+            return this.GetHandler().DisableBonusesAsync();
+        }
+
+        [Command("enableBonuses")]
+        [Summary("Makes the current game track bonuses from now on. This command will reset the current cycle (like !clear)")]
+        public Task EnableBonusesAsync()
+        {
+            return this.GetHandler().EnableBonusesAsync();
+        }
+
         [Command("setnewreader")]
         [Summary("Set another user as the reader.")]
         public Task SetNewReaderAsync([Summary("Mention of the new reader")] IGuildUser newReader)
@@ -58,7 +76,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
         }
 
         [Command("clear")]
-        [Summary("Clears the player queue and answers from this question, including scores from this question.")]
+        [Summary("Clears the player queue and answers from this question, including scores from this question. This can only be used during the tossup stage.")]
         public Task ClearAsync()
         {
             return this.GetHandler().ClearAsync();
@@ -81,7 +99,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
         private ReaderCommandHandler GetHandler()
         {
             // this.Context is null in the constructor, so create the handler in this method
-            return new ReaderCommandHandler(this.Context, this.Manager);
+            return new ReaderCommandHandler(this.Context, this.Manager, this.DatabaseActionFactory);
         }
     }
 }

--- a/QuizBowlDiscordScoreTracker/Database/DatabaseAction.cs
+++ b/QuizBowlDiscordScoreTracker/Database/DatabaseAction.cs
@@ -68,6 +68,12 @@ namespace QuizBowlDiscordScoreTracker.Database
             return guild.TeamRolePrefix;
         }
 
+        public async Task<bool> GetUseBonuses(ulong guildId)
+        {
+            GuildSetting guild = await this.AddOrGetGuildAsync(guildId);
+            return guild.UseBonuses;
+        }
+
         public async Task PairChannelsAsync(ulong guildId, ulong textChannelId, ulong voiceChannelId)
         {
             TextChannelSetting textChannel = await this.AddOrGetTextChannelAsync(guildId, textChannelId);
@@ -93,6 +99,13 @@ namespace QuizBowlDiscordScoreTracker.Database
         {
             GuildSetting guild = await this.AddOrGetGuildAsync(guildId);
             guild.TeamRolePrefix = prefix;
+            await this.Context.SaveChangesAsync();
+        }
+
+        public async Task SetUseBonuses(ulong guildId, bool useBonuses)
+        {
+            GuildSetting guild = await this.AddOrGetGuildAsync(guildId);
+            guild.UseBonuses = useBonuses;
             await this.Context.SaveChangesAsync();
         }
 

--- a/QuizBowlDiscordScoreTracker/Database/GuildSetting.cs
+++ b/QuizBowlDiscordScoreTracker/Database/GuildSetting.cs
@@ -7,6 +7,7 @@ namespace QuizBowlDiscordScoreTracker.Database
         // This should match the Guild ID
         public ulong GuildSettingId { get; set; }
         public string TeamRolePrefix { get; set; }
+        public bool UseBonuses { get; set; }
 
 #pragma warning disable CA2227 // Collection properties should be read only. This is an EF Core model class; the collection must be settable
         public ICollection<TextChannelSetting> TextChannels { get; set; }

--- a/QuizBowlDiscordScoreTracker/Format.cs
+++ b/QuizBowlDiscordScoreTracker/Format.cs
@@ -1,0 +1,43 @@
+﻿namespace QuizBowlDiscordScoreTracker
+{
+    public class Format
+    {
+        // This controls the format for games. Acf is unused for now, but will be used when we support a touranment mode
+        public static readonly Format Acf = new Format()
+        {
+            HighestPhaseIndexWithBonus = 20 - 1,
+            PhasesInRegulation = 20
+        };
+
+        public static readonly Format TossupShootout = new Format()
+        {
+            // No bonuses in a tossup shootout
+            HighestPhaseIndexWithBonus = -1,
+            PhasesInRegulation = int.MaxValue
+        };
+
+        public static readonly Format TossupBonusesShootout = new Format()
+        {
+            HighestPhaseIndexWithBonus = int.MaxValue,
+            PhasesInRegulation = int.MaxValue
+        };
+
+        public int HighestPhaseIndexWithBonus { get; set; }
+
+        public int PhasesInRegulation { get; set; }
+
+        // TODO: Add information to handle tiebreakers
+        // TODO: See if we can match the QB Schema to handle most cases
+
+        // TODO: We may need the team scores to determine if we have more phases. Move to a TryCreate pattern then?
+        public IPhaseState CreateNextPhase(int phaseIndex)
+        {
+            if (phaseIndex > this.HighestPhaseIndexWithBonus)
+            {
+                return new TossupOnlyPhaseState();
+            }
+
+            return new TossupBonusPhaseState();
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTracker/IPhaseState.cs
+++ b/QuizBowlDiscordScoreTracker/IPhaseState.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace QuizBowlDiscordScoreTracker
+{
+    public interface IPhaseState
+    {
+        IEnumerable<ScoreAction> OrderedScoreActions { get; }
+        PhaseStage CurrentStage { get; }
+
+        bool AddBuzz(Buzz player);
+        void Clear();
+        bool TryGetNextPlayer(out ulong nextPlayerId);
+        bool TryScoreBuzz(int score);
+        bool Undo(out ulong? userId);
+        bool WithdrawPlayer(ulong userId, string userTeamId);
+    }
+}

--- a/QuizBowlDiscordScoreTracker/ITossupBonusPhaseState.cs
+++ b/QuizBowlDiscordScoreTracker/ITossupBonusPhaseState.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace QuizBowlDiscordScoreTracker
+{
+    public interface ITossupBonusPhaseState
+    {
+        IReadOnlyCollection<int> BonusScores { get; }
+        bool HasBonus { get; }
+
+        bool TryScoreBonus(string bonusScore);
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Migrations/20201011004425_AddGuildSettingsUseBonuses.Designer.cs
+++ b/QuizBowlDiscordScoreTracker/Migrations/20201011004425_AddGuildSettingsUseBonuses.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QuizBowlDiscordScoreTracker.Database;
 
 namespace QuizBowlDiscordScoreTracker.Migrations
 {
     [DbContext(typeof(BotConfigurationContext))]
-    partial class BotConfigurationContextModelSnapshot : ModelSnapshot
+    [Migration("20201011004425_AddGuildSettings_UseBonuses")]
+    partial class AddGuildSettingsUseBonuses
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QuizBowlDiscordScoreTracker/Migrations/20201011004425_AddGuildSettingsUseBonuses.cs
+++ b/QuizBowlDiscordScoreTracker/Migrations/20201011004425_AddGuildSettingsUseBonuses.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace QuizBowlDiscordScoreTracker.Migrations
+{
+#pragma warning disable CA1062 // Validate arguments of public methods
+    public partial class AddGuildSettingsUseBonuses : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "UseBonuses",
+                table: "Guilds",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UseBonuses",
+                table: "Guilds");
+        }
+    }
+#pragma warning restore CA1062 // Validate arguments of public methods
+}

--- a/QuizBowlDiscordScoreTracker/PhaseScore.cs
+++ b/QuizBowlDiscordScoreTracker/PhaseScore.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace QuizBowlDiscordScoreTracker
+{
+    public class PhaseScore
+    {
+        public PhaseScore()
+        {
+            this.ScoringSplitsOnActions = Array.Empty<ScoringSplitOnScoreAction>();
+            this.BonusScores = Array.Empty<int>();
+        }
+
+        public IEnumerable<ScoringSplitOnScoreAction> ScoringSplitsOnActions { get; set; }
+
+        public string BonusTeamId { get; set; }
+
+        public IEnumerable<int> BonusScores { get; set; }
+    }
+}

--- a/QuizBowlDiscordScoreTracker/PhaseStage.cs
+++ b/QuizBowlDiscordScoreTracker/PhaseStage.cs
@@ -1,0 +1,9 @@
+﻿namespace QuizBowlDiscordScoreTracker
+{
+    public enum PhaseStage
+    {
+        Tossup,
+        Bonus,
+        Complete
+    }
+}

--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Company />
     <Product>Quiz Bowl Discord Score Tracker</Product>

--- a/QuizBowlDiscordScoreTracker/TeamNameParser.cs
+++ b/QuizBowlDiscordScoreTracker/TeamNameParser.cs
@@ -55,7 +55,7 @@ namespace QBDiscordScoreTracker
             }
 
             // Add the remaining team.
-            if (combinedTeamNames[combinedTeamNames.Length - 1] == ',' && possibleCommaEscapeStart)
+            if (combinedTeamNames[^1] == ',' && possibleCommaEscapeStart)
             {
                 errorMessage = "team missing from addTeams (trailing comma)";
                 return false;

--- a/QuizBowlDiscordScoreTracker/TossupBonusPhaseState.cs
+++ b/QuizBowlDiscordScoreTracker/TossupBonusPhaseState.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace QuizBowlDiscordScoreTracker
+{
+    public class TossupBonusPhaseState : PhaseState, ITossupBonusPhaseState
+    {
+        // Bonuses are generally 3 parts. We might support non-3 part bonuses in the future, so keep this flexible
+        internal const int DefaultBonusLength = 3;
+
+        private static readonly Regex SplitsRegex = new Regex(
+            $"^(0|10)(\\s*/\\s*(0|10)){{{DefaultBonusLength - 1}}}$", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+        private static readonly Regex BinarySplitsRegex = new Regex(
+            $"^(0|1){{{DefaultBonusLength}}}$", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+
+        private List<int> bonusScores;
+
+        public TossupBonusPhaseState() : base()
+        {
+            this.bonusScores = null;
+        }
+
+        public bool HasBonus => this.BonusScores != null;
+
+        public IReadOnlyCollection<int> BonusScores => this.bonusScores;
+
+        public override PhaseStage CurrentStage
+        {
+            get
+            {
+                if (!this.HasBonus)
+                {
+                    return PhaseStage.Tossup;
+                }
+
+                return this.BonusScores.Count > 0 ? PhaseStage.Complete : PhaseStage.Bonus;
+            }
+        }
+
+        public bool TryScoreBonus(string bonusScore)
+        {
+            Verify.IsNotNull(bonusScore, nameof(bonusScore));
+
+            // Formats that are supported
+            // - Total points when the parts can be inferred (0, 30)
+            // - Splits (0/0/0, 0/0/10, 10/10/10, etc.)
+            // - Binary-style splits (000, 001, 111, etc.)
+            bonusScore = bonusScore.Trim();
+            if (bonusScore == "0")
+            {
+                for (int i = 0; i < DefaultBonusLength; i++)
+                {
+                    this.bonusScores.Add(0);
+                }
+
+                return true;
+            }
+            else if (bonusScore == "30")
+            {
+                for (int i = 0; i < DefaultBonusLength; i++)
+                {
+                    this.bonusScores.Add(10);
+                }
+
+                return true;
+            }
+
+            Match match = SplitsRegex.Match(bonusScore);
+            if (match.Success)
+            {
+                string[] values = bonusScore.Split('/', DefaultBonusLength);
+                foreach (string value in values)
+                {
+                    string trimmedValue = value.Trim();
+
+                    // We have a real problem if we can't parse 0 or 10
+                    int numericValue = int.Parse(trimmedValue, CultureInfo.InvariantCulture);
+                    this.bonusScores.Add(numericValue);
+                }
+
+                return true;
+            }
+
+            match = BinarySplitsRegex.Match(bonusScore);
+            if (match.Success)
+            {
+                foreach (char value in bonusScore)
+                {
+                    // We have a real problem if we can't parse the digits
+                    int numericValue = value == '1' ? 10 : 0;
+                    this.bonusScores.Add(numericValue);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public override bool TryScoreBuzz(int score)
+        {
+            bool result = base.TryScoreBuzz(score);
+            if (result && score > 0)
+            {
+                // We have bonuses
+                this.bonusScores = new List<int>(DefaultBonusLength);
+            }
+
+            return result;
+        }
+
+        public override bool Undo(out ulong? userId)
+        {
+            if (this.HasBonus && this.BonusScores.Count > 0)
+            {
+                userId = null;
+                this.bonusScores.Clear();
+                return true;
+            }
+
+            // If we haven't scored the bonus, we're undoing something from the tossup phase.
+            // Make sure the bonus scores collection is null, then undo whatever happened during the tossup.
+            this.bonusScores = null;
+            return base.Undo(out userId);
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTracker/TossupOnlyPhaseState.cs
+++ b/QuizBowlDiscordScoreTracker/TossupOnlyPhaseState.cs
@@ -1,0 +1,9 @@
+﻿namespace QuizBowlDiscordScoreTracker
+{
+    public class TossupOnlyPhaseState : PhaseState
+    {
+        public override PhaseStage CurrentStage => this.Actions.TryPeek(out ScoreAction result) && result.Score > 0 ?
+                    PhaseStage.Complete :
+                    PhaseStage.Tossup;
+    }
+}

--- a/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
@@ -41,6 +41,75 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
+        public async Task DisableBonusesAlways()
+        {
+            this.CreateHandler(
+                out AdminCommandHandler handler,
+                out MessageStore messageStore);
+
+            // Enable, then disable the bonuses
+            using (BotConfigurationContext context = this.botConfigurationfactory.Create())
+            using (DatabaseAction action = new DatabaseAction(context))
+            {
+                await action.SetUseBonuses(DefaultGuildId, true);
+            }
+
+            await handler.GetDefaultFormatAsync();
+            Assert.AreEqual(
+                1, messageStore.ChannelEmbeds.Count, "Unexpected number of messages after getting the team role");
+            string getEmbed = messageStore.ChannelEmbeds[0];
+            Assert.IsTrue(
+                getEmbed.Contains("Require scoring bonuses?: Yes", StringComparison.InvariantCulture),
+                $"Enabled setting not in message \"{getEmbed}\"");
+            messageStore.Clear();
+
+            await handler.DisableBonusesAlwaysAsync();
+            Assert.AreEqual(
+                1, messageStore.ChannelMessages.Count, "Unexpected number of messages after setting the team role");
+            string setMessage = messageStore.ChannelMessages[0];
+            Assert.AreEqual(
+                "Scoring bonuses will no longer be required for every game in this server.",
+                setMessage,
+                "Unexpected message when enabled");
+
+            messageStore.Clear();
+
+            await handler.GetDefaultFormatAsync();
+            Assert.AreEqual(
+                1, messageStore.ChannelEmbeds.Count, "Unexpected number of messages after getting the team role");
+            getEmbed = messageStore.ChannelEmbeds[0];
+            Assert.IsTrue(
+                getEmbed.Contains("Require scoring bonuses?: No", StringComparison.InvariantCulture),
+                $"Disabled setting not in message \"{getEmbed}\"");
+        }
+
+        [TestMethod]
+        public async Task EnableBonusesAlways()
+        {
+            this.CreateHandler(
+                out AdminCommandHandler handler,
+                out MessageStore messageStore);
+            await handler.EnableBonusesAlwaysAsync();
+            Assert.AreEqual(
+                1, messageStore.ChannelMessages.Count, "Unexpected number of messages after setting the team role");
+            string setMessage = messageStore.ChannelMessages[0];
+            Assert.AreEqual(
+                "Scoring bonuses is now required for every game in this server.",
+                setMessage,
+                "Unexpected message when enabled");
+
+            messageStore.Clear();
+
+            await handler.GetDefaultFormatAsync();
+            Assert.AreEqual(
+                1, messageStore.ChannelEmbeds.Count, "Unexpected number of messages after getting the team role");
+            string getEmbed = messageStore.ChannelEmbeds[0];
+            Assert.IsTrue(
+                getEmbed.Contains("Require scoring bonuses?: Yes", StringComparison.InvariantCulture),
+                $"Enabled setting not in message \"{getEmbed}\"");
+        }
+
+        [TestMethod]
         public async Task SetTeamRole()
         {
             const string prefix = "Team #";

--- a/QuizBowlDiscordScoreTrackerUnitTests/ByRoleTeamManagerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/ByRoleTeamManagerTests.cs
@@ -129,7 +129,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             mockNonexistentUser.Setup(user => user.RoleIds).Returns(new ulong[] { NonTeamRoleId });
             users.Add(mockNonexistentUser.Object);
 
-            IReadOnlyCollection<IGuildUser> readonlyUsers = (IReadOnlyCollection<IGuildUser>)users;
+            IReadOnlyCollection<IGuildUser> readonlyUsers = users;
             mockGuild
                 .Setup(guild => guild.GetUsersAsync(It.IsAny<CacheMode>(), It.IsAny<RequestOptions>()))
                 .Returns<CacheMode, RequestOptions>((mode, options) => Task.FromResult(readonlyUsers));

--- a/QuizBowlDiscordScoreTrackerUnitTests/TossupBonusPhaseStateTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/TossupBonusPhaseStateTests.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using QuizBowlDiscordScoreTracker;
+
+namespace QuizBowlDiscordScoreTrackerUnitTests
+{
+    [TestClass]
+    public class TossupBonusPhaseStateTests
+    {
+        private static readonly Buzz DefaultBuzz = new Buzz()
+        {
+            TeamId = "10",
+            UserId = 1,
+            PlayerDisplayName = "Alice",
+            Timestamp = DateTime.Now
+        };
+
+        [TestMethod]
+        public void TestStagesForCorrectBuzz()
+        {
+            TossupBonusPhaseState phaseState = new TossupBonusPhaseState();
+            Assert.IsFalse(phaseState.HasBonus, "We should have a bonus on a correct buzz");
+            Assert.AreEqual(PhaseStage.Tossup, phaseState.CurrentStage, "We should be in the tossup phase");
+
+            phaseState.AddBuzz(DefaultBuzz);
+            Assert.IsTrue(phaseState.TryScoreBuzz(10), "Scoring the buzz should succeed");
+
+            Assert.IsTrue(phaseState.HasBonus, "We should have a bonus on a correct buzz");
+            Assert.AreEqual(PhaseStage.Bonus, phaseState.CurrentStage, "We should be in the bonus phase");
+
+            Assert.IsTrue(phaseState.TryScoreBonus("0"), "Scoring the bonus should succeed");
+            Assert.AreEqual(PhaseStage.Complete, phaseState.CurrentStage, "We should be done with this phase");
+        }
+
+        [TestMethod]
+        public void TestStagesForIncorrectBuzz()
+        {
+            TossupBonusPhaseState phaseState = new TossupBonusPhaseState();
+            Assert.IsFalse(phaseState.HasBonus, "We should have a bonus on a correct buzz");
+            Assert.AreEqual(PhaseStage.Tossup, phaseState.CurrentStage, "We should be in the tossup phase");
+
+            phaseState.AddBuzz(DefaultBuzz);
+            Assert.IsTrue(phaseState.TryScoreBuzz(0), "Scoring the buzz should succeed");
+
+            // Should be the same
+            Assert.IsFalse(phaseState.HasBonus, "We shouldn't have a bonus on an incorrect buzz");
+            Assert.AreEqual(PhaseStage.Tossup, phaseState.CurrentStage, "We should still be in the tossup phase");
+        }
+
+        [TestMethod]
+        public void ZeroStringScoredForBonus()
+        {
+            TossupBonusPhaseState phaseState = CreatePhaseInBonusStage();
+            Assert.IsTrue(phaseState.TryScoreBonus("0"), "Scoring the bonus should succeed");
+            Assert.AreEqual(
+                TossupBonusPhaseState.DefaultBonusLength, phaseState.BonusScores.Count, "We should have three parts scored");
+            Assert.IsTrue(
+                phaseState.BonusScores.All(score => score == 0),
+                $"Not all parts were scored a 0: {string.Join('/', phaseState.BonusScores)}");
+        }
+
+        [TestMethod]
+        public void ThirtyStringScoredForBonus()
+        {
+            TossupBonusPhaseState phaseState = CreatePhaseInBonusStage();
+            Assert.IsTrue(phaseState.TryScoreBonus("30"), "Scoring the bonus should succeed");
+            Assert.AreEqual(
+                TossupBonusPhaseState.DefaultBonusLength, phaseState.BonusScores.Count, "We should have three parts scored");
+            Assert.IsTrue(
+                phaseState.BonusScores.All(score => score == 10),
+                $"Not all parts were scored a 0: {string.Join('/', phaseState.BonusScores)}");
+        }
+
+        [TestMethod]
+        public void ThreeSplitsScoredForBonus()
+        {
+            TossupBonusPhaseState phaseState = CreatePhaseInBonusStage();
+            Assert.IsTrue(phaseState.TryScoreBonus("10/0/10"), "Scoring the bonus should succeed");
+            Assert.AreEqual(
+                TossupBonusPhaseState.DefaultBonusLength, phaseState.BonusScores.Count, "We should have three parts scored");
+            CollectionAssert.AreEqual(
+                new int[] { 10, 0, 10 },
+                phaseState.BonusScores.ToArray(),
+                $"Not all parts were scored correctly. Expected 10/0/10, got {string.Join('/', phaseState.BonusScores)}");
+        }
+
+        [TestMethod]
+        public void ThreeBinaryDigitsScoredForBonus()
+        {
+            TossupBonusPhaseState phaseState = CreatePhaseInBonusStage();
+            Assert.IsTrue(phaseState.TryScoreBonus("011"), "Scoring the bonus should succeed");
+            Assert.AreEqual(
+                TossupBonusPhaseState.DefaultBonusLength, phaseState.BonusScores.Count, "We should have three parts scored");
+            CollectionAssert.AreEqual(
+                new int[] { 0, 10, 10 },
+                phaseState.BonusScores.ToArray(),
+                $"Not all parts were scored correctly. Expected 0/10/10, got {string.Join('/', phaseState.BonusScores)}");
+        }
+
+        [TestMethod]
+        public void TenAndTwentyNotScoredForBonus()
+        {
+            TossupBonusPhaseState phaseState = CreatePhaseInBonusStage();
+            Assert.IsFalse(phaseState.TryScoreBonus("10"), "Scoring the bonus should've failed for 2 splits");
+            Assert.AreEqual(
+                0, phaseState.BonusScores.Count, "No bonus should've been scored for 10, since we don't know the splits");
+
+            Assert.IsFalse(phaseState.TryScoreBonus("20"), "Scoring the bonus should've failed for 4 splits");
+            Assert.AreEqual(
+                0, phaseState.BonusScores.Count, "No bonus should've been scored for 20, since we don't know the splits");
+        }
+
+        [TestMethod]
+        public void NonThreeSplitsNotScoredForBonus()
+        {
+            TossupBonusPhaseState phaseState = CreatePhaseInBonusStage();
+            Assert.IsFalse(phaseState.TryScoreBonus("10/0"), "Scoring the bonus should've failed for 2 splits");
+            Assert.AreEqual(0, phaseState.BonusScores.Count, "No bonus should've been scored for 2 splits");
+
+            Assert.IsFalse(phaseState.TryScoreBonus("10/0/10/10"), "Scoring the bonus should've failed for 4 splits");
+            Assert.AreEqual(0, phaseState.BonusScores.Count, "No bonus should've been scored for 4 splits");
+        }
+
+        [TestMethod]
+        public void NonThreeBinaryDigitsNotScoredForBonus()
+        {
+            TossupBonusPhaseState phaseState = CreatePhaseInBonusStage();
+            Assert.IsFalse(phaseState.TryScoreBonus("11"), "Scoring the bonus should've failed for 2 splits");
+            Assert.AreEqual(0, phaseState.BonusScores.Count, "No bonus should've been scored for 2 digits");
+
+            Assert.IsFalse(phaseState.TryScoreBonus("1011"), "Scoring the bonus should've failed for 4 splits");
+            Assert.AreEqual(0, phaseState.BonusScores.Count, "No bonus should've been scored for 4 digits");
+        }
+
+        // TODO: Add tests for Undo
+        [TestMethod]
+        public void UndoScoredTossup()
+        {
+            TossupBonusPhaseState phaseState = new TossupBonusPhaseState();
+            phaseState.AddBuzz(DefaultBuzz);
+            Assert.IsTrue(phaseState.TryScoreBuzz(-5), "Scoring the first buzz should succeed");
+
+            Assert.IsTrue(
+                phaseState.AlreadyBuzzedPlayerIds.Contains(DefaultBuzz.UserId),
+                "Default player not in the list of already buzzed players");
+            Assert.AreEqual(1, phaseState.Actions.Count, "Unexpected number of buzzes recorded");
+
+            ulong secondBuzzPlayerId = DefaultBuzz.UserId + 1;
+            string secondTeamId = $"{DefaultBuzz.TeamId}1";
+            Buzz incorrectBuzz = new Buzz()
+            {
+                TeamId = secondTeamId,
+                PlayerDisplayName = "Bob",
+                UserId = secondBuzzPlayerId,
+                Timestamp = DateTime.Now + TimeSpan.FromSeconds(1)
+            };
+
+            phaseState.AddBuzz(incorrectBuzz);
+            Assert.IsTrue(phaseState.TryScoreBuzz(0), "Scoring the second buzz should succeed");
+            Assert.IsTrue(
+                phaseState.AlreadyBuzzedPlayerIds.Contains(secondBuzzPlayerId),
+                "Second player not in the list of already buzzed players");
+            Assert.AreEqual(2, phaseState.Actions.Count, "Unexpected number of buzzes recorded after the second buzz");
+
+            phaseState.Undo(out ulong? userId);
+            Assert.AreEqual(secondBuzzPlayerId, userId, "Unexpected userId returned by Undo");
+            Assert.IsTrue(
+                phaseState.AlreadyScoredTeamIds.Contains(DefaultBuzz.TeamId),
+                "Default player not in the list of already scored teams after the first undo");
+            Assert.IsFalse(
+                phaseState.AlreadyScoredTeamIds.Contains(secondTeamId),
+                "Second player not in the list of already scored teams after the first undo");
+            Assert.AreEqual(1, phaseState.Actions.Count, "Unexpected number of buzzes recorded after the first undo");
+
+            phaseState.Undo(out userId);
+            Assert.AreEqual(DefaultBuzz.UserId, userId, "Unexpected userId returned by Undo");
+            Assert.IsFalse(
+                phaseState.AlreadyScoredTeamIds.Contains(DefaultBuzz.TeamId),
+                "Default player not in the list of already scored teams after the second undo");
+            Assert.AreEqual(0, phaseState.Actions.Count, "Unexpected number of buzzes recorded after the second undo");
+        }
+
+        [TestMethod]
+        public void UndoBonusBeforeScoringIt()
+        {
+            TossupBonusPhaseState phaseState = CreatePhaseInBonusStage();
+
+            phaseState.Undo(out ulong? userId);
+            Assert.IsFalse(phaseState.HasBonus, "We shouldn't have a bonus now");
+            Assert.AreEqual(PhaseStage.Tossup, phaseState.CurrentStage, "We should be in the tossup stage");
+            Assert.AreEqual(DefaultBuzz.UserId, userId, "Unexpected userId");
+            Assert.IsFalse(
+                phaseState.AlreadyScoredTeamIds.Contains(DefaultBuzz.TeamId),
+                "Default player not in the list of already scored teams after the second undo");
+            Assert.AreEqual(0, phaseState.Actions.Count, "Unexpected number of buzzes recorded after the second undo");
+        }
+
+        [TestMethod]
+        public void UndoBonusAfterScoringIt()
+        {
+            TossupBonusPhaseState phaseState = CreatePhaseInBonusStage();
+            Assert.IsTrue(phaseState.TryScoreBonus("0"), "Scoring the bonus should've succeeded");
+            Assert.AreEqual(
+                TossupBonusPhaseState.DefaultBonusLength, phaseState.BonusScores.Count, "We should have three parts scored");
+
+            phaseState.Undo(out ulong? userId);
+            Assert.IsNull(userId, "userId should be null (scoring a bonus)");
+            Assert.AreEqual(0, phaseState.BonusScores.Count, "Bonus scores should be cleared, but not gone");
+            Assert.AreEqual(PhaseStage.Bonus, phaseState.CurrentStage, "Unexpected stage after first undo");
+            Assert.IsTrue(
+                phaseState.AlreadyScoredTeamIds.Contains(DefaultBuzz.TeamId),
+                "Default player not in the list of already scored teams after the second undo");
+            Assert.AreEqual(1, phaseState.Actions.Count, "Unexpected number of buzzes recorded after the second undo");
+
+            phaseState.Undo(out userId);
+            Assert.AreEqual(DefaultBuzz.UserId, userId, "userId should not be null after undoing the bonus score");
+            Assert.IsNull(phaseState.BonusScores, "Bonus scores should be gone");
+            Assert.AreEqual(PhaseStage.Tossup, phaseState.CurrentStage, "Unexpected stage after second undo");
+        }
+
+        private static TossupBonusPhaseState CreatePhaseInBonusStage()
+        {
+            TossupBonusPhaseState phaseState = new TossupBonusPhaseState();
+            phaseState.AddBuzz(DefaultBuzz);
+            phaseState.TryScoreBuzz(10);
+            return phaseState;
+        }
+    }
+}


### PR DESCRIPTION
- Add support for bonuses (#30)
  - Bonuses can always be tracked at the server level by server admins with !enableBonusesAlways. This can be unset with !disableBonusesAlways
  - Bonuses can be tracked for the current game with !enableBonuses, and untracked with !disableBonuses
  - Bonuses are always assumed to be 3 parts
  - The reader can score bonuses in one of the ways
    - Using splits, where 10 is a get and 0 is a miss (e.g. 0/10/10)
    - Using binary, where 1 is a get and 0 is a miss (e.g. 011)
    - "0" or "30" are translated to 0/0/0 and 10/10/10 automatically
- Add a limit to the number of phases/cycles in a game (2000)
- Fix a bug where undo wouldn't prompt the correct player if the last buzz was done by a player who left the server