### PR TITLE
25: Have !checkPermissions take a channel as an argument

### DIFF
--- a/QuizBowlDiscordScoreTracker/Commands/AdminCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/AdminCommandHandler.cs
@@ -26,9 +26,10 @@ namespace QuizBowlDiscordScoreTracker.Commands
 
         private IDatabaseActionFactory DatabaseActionFactory { get; }
 
-        public async Task CheckPermissionsAsync()
+        public async Task CheckPermissionsAsync([Summary("Text channel mention (#textChannelName)")] IMessageChannel messageChannel)
         {
-            if (!(this.Context.Channel is IGuildChannel guildChannel))
+            messageChannel ??= this.Context.Channel;
+            if (!(messageChannel is IGuildChannel guildChannel))
             {
                 return;
             }

--- a/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
@@ -17,10 +17,11 @@ namespace QuizBowlDiscordScoreTracker.Commands
         private IDatabaseActionFactory DatabaseActionFactory { get; }
 
         [Command("checkPermissions")]
-        [Summary("Checks if the bot has all the required permissions.")]
-        public Task CheckPermissionsAsync()
+        [Summary("Checks if the bot has all the required permissions. " + 
+                 "Omitting a channel mention will check the current channel's permissions.")]
+        public Task CheckPermissionsAsync([Summary("Text channel mention (#textChannelName)")] ITextChannel messageChannel)
         {
-            return this.GetHandler().CheckPermissionsAsync();
+            return this.GetHandler().CheckPermissionsAsync(messageChannel);
         }
 
         [Command("clearTeamRolePrefix")]


### PR DESCRIPTION
 - Makes the checkPermissions command take a mentioned text channel as an argument
 - Omitting the argument defaults to the current channel

Resolves #25 