### PR TITLE
25: Have !checkPermissions take a channel as an argument

### DIFF
--- a/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using QuizBowlDiscordScoreTracker.Database;
@@ -17,10 +18,11 @@ namespace QuizBowlDiscordScoreTracker.Commands
         private IDatabaseActionFactory DatabaseActionFactory { get; }
 
         [Command("checkPermissions")]
-        [Summary("Checks if the bot has all the required permissions.")]
-        public Task CheckPermissionsAsync()
+        [Summary("Checks if the bot has all the required permissions. " + 
+                 "Omitting a channel mention will check the current channel's permissions.")]
+        public Task CheckPermissionsAsync([Optional][Summary("Text channel mention (#textChannelName)")] ITextChannel messageChannel)
         {
-            return this.GetHandler().CheckPermissionsAsync();
+            return this.GetHandler().CheckPermissionsAsync(messageChannel);
         }
 
         [Command("clearTeamRolePrefix")]


### PR DESCRIPTION
 - Makes the checkPermissions command take a mentioned text channel as an argument
 - Omitting the argument defaults to the current channel

Resolves #25 