### PR TITLE
Merged PR 135: Readers can now be restricted by role (v3.5.1)

### DIFF
--- a/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
@@ -23,6 +23,14 @@ namespace QuizBowlDiscordScoreTracker.Commands
             return this.GetHandler().CheckPermissionsAsync();
         }
 
+        [Command("clearReaderRolePrefix")]
+        [Summary("Disables restricting readers to those who have a role with the same prefix. Only server admins can" +
+            "invoke this.")]
+        public Task ClearReaderRolePrefixAsync()
+        {
+            return this.GetHandler().ClearReaderRolePrefixAsync();
+        }
+
         [Command("clearTeamRolePrefix")]
         [Summary("Disables pairing players together based on sharing a role with the same prefix. Only server " +
             "admins can invoke this.")]
@@ -52,6 +60,14 @@ namespace QuizBowlDiscordScoreTracker.Commands
             return this.GetHandler().GetPairedChannelAsync(textChannel);
         }
 
+        [Command("getReaderRolePrefix")]
+        [Summary("Posts the prefix for the role name used to restrict who can read, if it exists. Only server admins " +
+            "can invoke this.")]
+        public Task GetReaderRolePrefixAsync()
+        {
+            return this.GetHandler().GetReaderRolePrefixAsync();
+        }
+
         [Command("getTeamRolePrefix")]
         [Summary("Posts the prefix for the role name used to assign teams, if it exists. Only server admins can " +
             "invoke this.")]
@@ -75,6 +91,16 @@ namespace QuizBowlDiscordScoreTracker.Commands
             [Remainder][Summary("Name of the voice channel (no # included)")] string voiceChannelName)
         {
             return this.GetHandler().PairChannelsAsync(textChannel, voiceChannelName);
+        }
+
+        [Command("setReaderRolePrefix")]
+        [Summary("Only users who have a role with this prefix will be allowed to use !read. For example, if a user " +
+            @"has the role ""Readers"", and the prefix is set to ""Reader"", then the user will be able to use !read." +
+            @"Only server admins can invoke this.")]
+        public Task SetReaderRolePrefixAsync(
+            [Remainder][Summary("Prefix for roles that are used to group players into teams")] string prefix)
+        {
+            return this.GetHandler().SetReaderRolePrefixAsync(prefix);
         }
 
         [Command("setTeamRolePrefix")]

--- a/QuizBowlDiscordScoreTracker/Commands/GeneralCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/GeneralCommandHandler.cs
@@ -218,6 +218,19 @@ namespace QuizBowlDiscordScoreTracker.Commands
                 return;
             }
 
+            string readerRolePrefix;
+            using (DatabaseAction action = this.DatabaseActionFactory.Create())
+            {
+                readerRolePrefix = await action.GetReaderRolePrefixAsync(this.Context.Guild.Id);
+            }
+
+            if (!user.CanRead(this.Context.Guild, readerRolePrefix))
+            {
+                await this.Context.Channel.SendMessageAsync(
+                    @$"{user.Mention} can't read because they don't have a role starting with the prefix ""{readerRolePrefix}"".");
+                return;
+            }
+
             state.ReaderId = this.Context.User.Id;
 
             if (this.Context.Channel is IGuildChannel guildChannel)

--- a/QuizBowlDiscordScoreTracker/Database/GuildSetting.cs
+++ b/QuizBowlDiscordScoreTracker/Database/GuildSetting.cs
@@ -6,6 +6,7 @@ namespace QuizBowlDiscordScoreTracker.Database
     {
         // This should match the Guild ID
         public ulong GuildSettingId { get; set; }
+        public string ReaderRolePrefix { get; set; }
         public string TeamRolePrefix { get; set; }
         public bool UseBonuses { get; set; }
 

--- a/QuizBowlDiscordScoreTracker/IGuildUserExtensions.cs
+++ b/QuizBowlDiscordScoreTracker/IGuildUserExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Linq;
+using Discord;
+
+namespace QuizBowlDiscordScoreTracker
+{
+    public static class IGuildUserExtensions
+    {
+        public static bool CanRead(this IGuildUser user, IGuild guild, string readerRolePrefix)
+        {
+            return user != null && guild != null && 
+                (readerRolePrefix == null || guild.Roles
+                .Where(role => role.Name.StartsWith(readerRolePrefix, StringComparison.InvariantCultureIgnoreCase))
+                .Select(role => role.Id)
+                .Intersect(user.RoleIds)
+                .Any());
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Migrations/20201027041130_ReaderRolePrefix.Designer.cs
+++ b/QuizBowlDiscordScoreTracker/Migrations/20201027041130_ReaderRolePrefix.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QuizBowlDiscordScoreTracker.Database;
 
 namespace QuizBowlDiscordScoreTracker.Migrations
 {
     [DbContext(typeof(BotConfigurationContext))]
-    partial class BotConfigurationContextModelSnapshot : ModelSnapshot
+    [Migration("20201027041130_ReaderRolePrefix")]
+    partial class ReaderRolePrefix
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QuizBowlDiscordScoreTracker/Migrations/20201027041130_ReaderRolePrefix.cs
+++ b/QuizBowlDiscordScoreTracker/Migrations/20201027041130_ReaderRolePrefix.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace QuizBowlDiscordScoreTracker.Migrations
+{
+#pragma warning disable CA1062 // Validate arguments of public methods
+    public partial class ReaderRolePrefix : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ReaderRolePrefix",
+                table: "Guilds",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ReaderRolePrefix",
+                table: "Guilds");
+        }
+    }
+#pragma warning restore CA1062 // Validate arguments of public methods
+}

--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.5.0</Version>
+    <Version>3.5.1</Version>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Company />
     <Product>Quiz Bowl Discord Score Tracker</Product>

--- a/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
@@ -110,6 +110,95 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
+        public async Task SetReaderRole()
+        {
+            const string prefix = "Reader";
+            const string newPrefix = "The Reader";
+
+            this.CreateHandler(
+                out AdminCommandHandler handler,
+                out MessageStore messageStore);
+            await handler.SetReaderRolePrefixAsync(prefix);
+            Assert.AreEqual(
+                1, messageStore.ChannelMessages.Count, "Unexpected number of messages after setting the team role");
+            string setMessage = messageStore.ChannelMessages[0];
+            Assert.IsTrue(
+                setMessage.Contains(prefix, StringComparison.InvariantCulture),
+                $"Prefix not in message \"{setMessage}\"");
+
+            messageStore.Clear();
+
+            await handler.GetReaderRolePrefixAsync();
+            Assert.AreEqual(
+                1, messageStore.ChannelMessages.Count, "Unexpected number of messages after getting the team role");
+            string getMessage = messageStore.ChannelMessages[0];
+            Assert.IsTrue(
+                getMessage.Contains(prefix, StringComparison.InvariantCulture),
+                $"Prefix not in message \"{getMessage}\"");
+            Assert.AreNotEqual(setMessage, getMessage, "Get and set messages should be different");
+
+            messageStore.Clear();
+
+            await handler.SetReaderRolePrefixAsync(newPrefix);
+            Assert.AreEqual(
+                1, messageStore.ChannelMessages.Count, "Unexpected number of messages after updating the team role");
+            setMessage = messageStore.ChannelMessages[0];
+            Assert.IsTrue(
+                setMessage.Contains(newPrefix, StringComparison.InvariantCulture),
+                $"Prefix not in message \"{setMessage}\" after update");
+
+            messageStore.Clear();
+
+            await handler.GetReaderRolePrefixAsync();
+            Assert.AreEqual(
+                1,
+                messageStore.ChannelMessages.Count,
+                "Unexpected number of messages when getting the team role after the update");
+            getMessage = messageStore.ChannelMessages[0];
+            Assert.IsTrue(
+                getMessage.Contains(prefix, StringComparison.InvariantCulture),
+                $"Prefix not in message \"{getMessage}\" after update");
+            Assert.AreNotEqual(setMessage, getMessage, "Get and set messages should be different after update");
+        }
+
+        [TestMethod]
+        public async Task ClearReaderRolePrefix()
+        {
+            const string prefix = "Reader";
+            this.CreateHandler(
+                out AdminCommandHandler handler,
+                out MessageStore messageStore);
+
+            await handler.SetReaderRolePrefixAsync(prefix);
+            Assert.AreEqual(
+                1, messageStore.ChannelMessages.Count, "Unexpected number of messages after setting the team role");
+            string setMessage = messageStore.ChannelMessages[0];
+            Assert.IsTrue(
+                setMessage.Contains(prefix, StringComparison.InvariantCulture),
+                $"Prefix not in message \"{setMessage}\"");
+
+            messageStore.Clear();
+
+            await handler.ClearReaderRolePrefixAsync();
+            Assert.AreEqual(
+                1, messageStore.ChannelMessages.Count, "Unexpected number of messages after updating the team role");
+            string clearMessage = messageStore.ChannelMessages[0];
+            Assert.IsTrue(
+                clearMessage.Contains("unset", StringComparison.InvariantCulture),
+                @$"""unset"" not in message ""{clearMessage}"" after update");
+
+            messageStore.Clear();
+
+            await handler.GetReaderRolePrefixAsync();
+            Assert.AreEqual(
+                1,
+                messageStore.ChannelMessages.Count,
+                "Unexpected number of messages when getting the team role after the update");
+            string getMessage = messageStore.ChannelMessages[0];
+            Assert.AreEqual("No reader prefix used", getMessage, $"The team role prefix was not cleared");
+        }
+
+        [TestMethod]
         public async Task SetTeamRole()
         {
             const string prefix = "Team #";

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This is a Discord bot which keeps track of who buzzed in, as well as each player
 - Unzip the release
 - Create your own config file. Use the sampleConfig.txt file as an example. Your file should be called config.txt.
 - Go to https://discordapp.com/developers to register your instance of the bot
+  - Make sure that the bot has both the Presence and Server Members Intent, which you can set in the Bot pane of the application view
   - Update token.txt with the client secret from your registered Discord bot
   - Visit this site (with your bot's client ID) to add the bot to your channel
     - https://discordapp.com/oauth2/authorize?client_id=CLIENTID&scope=bot


### PR DESCRIPTION
- Readers can now be restricted by a user's roles (#48)
- Clear now sends a message telling the reader that the command was successful (#49)
- Fixed an issue where database entries could be cleared even when the export count wasn't at its minimum
- Bumped version to 3.5.1