### PR TITLE
#53: Don't allow bots to export

### DIFF
--- a/QuizBowlDiscordScoreTracker/Commands/ReaderCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/ReaderCommandHandler.cs
@@ -182,6 +182,12 @@ namespace QuizBowlDiscordScoreTracker.Commands
 
         public async Task ExportToFileAsync()
         {
+            if (this.Context.User.IsBot)
+            {
+                // Cannot export to file as a bot
+                return;
+            }
+            
             if (!this.Manager.TryGet(this.Context.Channel.Id, out GameState game))
             {
                 // This command only works during a game


### PR DESCRIPTION
 - Adds a check in the exportToFile method for whether the user is a bot

Previously, the exportToFile command could only be called by a reader or admin. Now the command can only be called by a reader or admin **who is not a bot**

This uses discord's isBot flag (the blue "BOT" tag)