### PR TITLE
#60: Allow for a default enable/disable bonuses state

### DIFF
--- a/QuizBowlDiscordScoreTracker/Commands/AdminCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/AdminCommandHandler.cs
@@ -126,7 +126,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
             await this.Context.Channel.SendMessageAsync("Prefix unset. Roles no longer determine who is on a team.");
         }
 
-        public async Task DisableBonusesAlwaysAsync()
+        public async Task DisableBonusesByDefaultAsync()
         {
             using (DatabaseAction action = this.DatabaseActionFactory.Create())
             {
@@ -135,10 +135,10 @@ namespace QuizBowlDiscordScoreTracker.Commands
 
             Logger.Information($"Use Bonuses set to false in guild {this.Context.Guild.Id} by user {this.Context.User.Id}");
             await this.Context.Channel.SendMessageAsync(
-                "Scoring bonuses will no longer be required for every game in this server.");
+                "Scoring bonuses will no longer be enabled for every game in this server.");
         }
 
-        public async Task EnableBonusesAlwaysAsync()
+        public async Task EnableBonusesByDefaultAsync()
         {
             using (DatabaseAction action = this.DatabaseActionFactory.Create())
             {
@@ -146,7 +146,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
             }
 
             Logger.Information($"Use Bonuses set to true in guild {this.Context.Guild.Id} by user {this.Context.User.Id}");
-            await this.Context.Channel.SendMessageAsync("Scoring bonuses is now required for every game in this server.");
+            await this.Context.Channel.SendMessageAsync("Scoring bonuses is now enabled for every game in this server.");
         }
 
         public async Task GetDefaultFormatAsync()

--- a/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
@@ -41,18 +41,18 @@ namespace QuizBowlDiscordScoreTracker.Commands
             return this.GetHandler().ClearTeamRolePrefixAsync();
         }
 
-        [Command("disableBonusesAlways")]
-        [Summary("Ensures that bonuses are never tracked in this server.")]
+        [Command("disableBonusesByDefault")]
+        [Summary("Ensures that bonuses are not tracked by default in this server.")]
         public Task DisableBonusesAsync()
         {
-            return this.GetHandler().DisableBonusesAlwaysAsync();
+            return this.GetHandler().DisableBonusesByDefaultAsync();
         }
 
-        [Command("enableBonusesAlways")]
-        [Summary("Makes scoring bonuses in a game required in this server.")]
+        [Command("enableBonusesByDefault")]
+        [Summary("Makes scoring bonuses in a game enabled by default in this server.")]
         public Task EnableBonusesAsync()
         {
-            return this.GetHandler().EnableBonusesAlwaysAsync();
+            return this.GetHandler().EnableBonusesByDefaultAsync();
         }
 
         [Command("getPairedChannel")]

--- a/QuizBowlDiscordScoreTracker/Commands/ReaderCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/ReaderCommandHandler.cs
@@ -146,16 +146,18 @@ namespace QuizBowlDiscordScoreTracker.Commands
                 alwaysUseBonuses = await action.GetUseBonuses(this.Context.Guild.Id);
             }
 
-            if (alwaysUseBonuses)
-            {
-                await this.Context.Channel.SendMessageAsync(
-                    "Bonuses are always tracked in this server. Run !disableBonusesAlways and restart the game to stop tracking bonuses.");
-                return;
-            }
-
             // TODO: We should look into cloning the format and changing the HighestPhaseIndexWithBonus field. This
             // would require another argument for the enable command, though, since it requires a number
             game.Format = Format.TossupShootout;
+            
+            if (alwaysUseBonuses)
+            {
+                await this.Context.Channel.SendMessageAsync(
+                    "Bonuses are no longer being tracked for this game only. Run !disableBonusesAlways to stop " +
+                    "tracking bonuses on this server by default.\nScores for the current question have been cleared.");
+                return;
+            }
+            
             await this.Context.Channel.SendMessageAsync(
                 "Bonuses are no longer being tracked. Scores for the current question have been cleared.");
         }

--- a/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
@@ -63,7 +63,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 $"Enabled setting not in message \"{getEmbed}\"");
             messageStore.Clear();
 
-            await handler.DisableBonusesAlwaysAsync();
+            await handler.DisableBonusesByDefaultAsync();
             Assert.AreEqual(
                 1, messageStore.ChannelMessages.Count, "Unexpected number of messages after setting the team role");
             string setMessage = messageStore.ChannelMessages[0];
@@ -84,12 +84,12 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
-        public async Task EnableBonusesAlways()
+        public async Task EnableBonusesByDefault()
         {
             this.CreateHandler(
                 out AdminCommandHandler handler,
                 out MessageStore messageStore);
-            await handler.EnableBonusesAlwaysAsync();
+            await handler.EnableBonusesByDefaultAsync();
             Assert.AreEqual(
                 1, messageStore.ChannelMessages.Count, "Unexpected number of messages after setting the team role");
             string setMessage = messageStore.ChannelMessages[0];

--- a/QuizBowlDiscordScoreTrackerUnitTests/ReaderCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/ReaderCommandHandlerTests.cs
@@ -415,7 +415,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
-        public async Task DisableBonusesFailsIfEnableBonusAlwaysSet()
+        public async Task DisableBonusesSucceedsIfEnableBonusSetByDefault()
         {
             this.CreateHandler(
                 out ReaderCommandHandler handler, out GameState currentGame, out MessageStore messageStore);
@@ -431,10 +431,10 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             Assert.AreEqual(1, messageStore.ChannelMessages.Count, "Unexpected number of channel messages.");
             string message = messageStore.ChannelMessages.First();
             Assert.AreEqual(
-                "Bonuses are always tracked in this server. Run !disableBonusesAlways and restart the game to stop tracking bonuses.",
+                "Bonuses are no longer being tracked for this game only. Run !disableBonusesAlways to stop tracking bonuses on this server by default.",
                 message,
                 $"Unexpected message");
-            Assert.AreEqual(Format.TossupBonusesShootout, currentGame.Format, "Unexpected format");
+            Assert.AreEqual(Format.TossupShootout, currentGame.Format, "Unexpected format");
         }
 
         [TestMethod]


### PR DESCRIPTION
 - Bonuses can be enabled/disabled for all games regardless of server default.
 - A different message is provided when !disableBonuses is run with !enableBonusesAlways active
 - !disableBonuses successfully runs when !enableBonusesAlways is active

This changes the behavior of the !enableBonusesAlways and !disableBonusesAlways to no longer function as a forced default state, but rather a default that all new games experience.

Cases:
enabled by default, disable for 1 game:
 - succeeds, with message reminding player of how to disable for all games

disabled by default, enable for 1 game:
 - succeeds, unchanged functionality (no message about how to enable bonuses by default)

Resolves #60 