### PR TITLE
#59: !join can allow players to join case-sensitive teams

### DIFF
--- a/QuizBowlDiscordScoreTracker/TeamManager/ByCommandTeamManager.cs
+++ b/QuizBowlDiscordScoreTracker/TeamManager/ByCommandTeamManager.cs
@@ -70,6 +70,8 @@ namespace QuizBowlDiscordScoreTracker.TeamManager
                 return false;
             }
 
+            // Correct any case irregularities from the player by replacing with "default" casing
+            teamName = this.TeamIdToName[teamName];
             this.PlayerIdToTeamId[userId] = (teamName, playerDisplayName);
             return true;
         }

--- a/QuizBowlDiscordScoreTrackerUnitTests/GeneralCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/GeneralCommandHandlerTests.cs
@@ -1415,6 +1415,21 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
+        public async Task JoinTeamCaseInsensitiveSucceeds()
+        {
+            const ulong userId = 1;
+            this.InitializeHandler(DefaultIds, userId, TeamManagerType.ByCommand);
+            ByCommandTeamManager teamManager = this.Game.TeamManager as ByCommandTeamManager;
+            Assert.IsTrue(teamManager.TryAddTeam(FirstTeamName, out _), "Couldn't add team");
+
+            Assert.IsNull(await teamManager.GetTeamIdOrNull(userId), "User shouldn't be on a team yet");
+            string upperFirstTeamName = FirstTeamName.ToUpper();
+            await this.Handler.JoinTeamAsync(upperFirstTeamName);
+            Assert.AreEqual(FirstTeamName, await teamManager.GetTeamIdOrNull(userId), "User didn't join the team");
+            this.MessageStore.VerifyChannelMessages($@"@User_{userId} is on team ""{FirstTeamName}""");
+        }
+        
+        [TestMethod]
         public async Task JoinNonexistentTeamFails()
         {
             const ulong userId = 1;


### PR DESCRIPTION
 - Forces all case variations of team names to return to the original spelling

When calling !score when teammates would fail to use the same casing in their team name, it would result in situations where the call would succeed (as the dictionary was case-insensitive), but the player's team name would use the player's casing. This would result in the scoreboard having players on team Alpha and team ALPHA listed separately.

One peculiarity of the current solution is that the success message still uses the user's casing of their team name, even though they will be added to the correct casing team. In the example from the test cases, the player succeeds in joining team Alpha using command !join ALPHA with a response message "@mention is on ALPHA"

Resolves #59 