### PR TITLE
Merged PR 139: Bump to 3.6.0 (UCSD Google Sheet export, bug fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,3 +270,4 @@ QuizBowlDiscordScoreTracker/config.txt
 vendor/
 
 /QuizBowlDiscordScoreTracker/Properties/launchsettings.json
+/QuizBowlDiscordScoreTracker/Properties/PublishProfiles/IISProfile.pubxml

--- a/APACHE_LICENSE.txt
+++ b/APACHE_LICENSE.txt
@@ -1,4 +1,4 @@
-This applies to the EntityFramework and Sqlite DLLs (Microsoft.EntityFramework.*.dll, SQLite*.dll)
+This applies to the Google Sheets, EntityFramework, and Sqlite DLLs (Microsoft.EntityFramework.*.dll, SQLite*.dll)
 
 
                                  Apache License

--- a/QuizBowlDiscordScoreTracker/Commands/GeneralCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/GeneralCommandHandler.cs
@@ -211,18 +211,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
                 return;
             }
 
-            if (!(this.Manager.TryGet(this.Context.Channel.Id, out GameState state) ||
-                this.Manager.TryCreate(this.Context.Channel.Id, out state)))
-            {
-                // Couldn't add a new reader.
-                return;
-            }
-            else if (state.ReaderId != null)
-            {
-                // We already have a reader, so do nothing.
-                return;
-            }
-
+            // This needs to happen before we try creating a game
             string readerRolePrefix;
             using (DatabaseAction action = this.DatabaseActionFactory.Create())
             {
@@ -233,6 +222,18 @@ namespace QuizBowlDiscordScoreTracker.Commands
             {
                 await this.Context.Channel.SendMessageAsync(
                     @$"{user.Mention} can't read because they don't have a role starting with the prefix ""{readerRolePrefix}"".");
+                return;
+            }
+
+            if (!(this.Manager.TryGet(this.Context.Channel.Id, out GameState state) ||
+                this.Manager.TryCreate(this.Context.Channel.Id, out state)))
+            {
+                // Couldn't add a new reader.
+                return;
+            }
+            else if (state.ReaderId != null)
+            {
+                // We already have a reader, so do nothing.
                 return;
             }
 

--- a/QuizBowlDiscordScoreTracker/IGuildUserExtensions.cs
+++ b/QuizBowlDiscordScoreTracker/IGuildUserExtensions.cs
@@ -8,7 +8,7 @@ namespace QuizBowlDiscordScoreTracker
     {
         public static bool CanRead(this IGuildUser user, IGuild guild, string readerRolePrefix)
         {
-            return user != null && guild != null && 
+            return user != null && guild != null &&
                 (readerRolePrefix == null || guild.Roles
                 .Where(role => role.Name.StartsWith(readerRolePrefix, StringComparison.InvariantCultureIgnoreCase))
                 .Select(role => role.Id)

--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.5.1</Version>
+    <Version>3.6.0</Version>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Company />
     <Product>Quiz Bowl Discord Score Tracker</Product>
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.95.3" />
     <PackageReference Include="Discord.Net" Version="2.2.0" />
+    <PackageReference Include="Google.Apis.Sheets.v4" Version="1.49.0.2111" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/QuizBowlDiscordScoreTracker/Scoresheet/ExcelFileScoresheetGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/ExcelFileScoresheetGenerator.cs
@@ -49,7 +49,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
             IEnumerable<PhaseScore> phaseScores = await game.GetPhaseScores();
             int phaseScoresCount = phaseScores.Count();
             if (phaseScoresCount > PhasesLimit + 1 ||
-                (phaseScoresCount == PhasesLimit && phaseScores.Last().ScoringSplitsOnActions.Any()))
+                (phaseScoresCount == PhasesLimit + 1 && phaseScores.Last().ScoringSplitsOnActions.Any()))
             {
                 return new FailureResult<Stream>(
                     "Export only currently works if there are at most 24 tosusps answered in a game.");

--- a/QuizBowlDiscordScoreTracker/Scoresheet/GoogleSheetsApi.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/GoogleSheetsApi.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Services;
+using Google.Apis.Sheets.v4;
+using Google.Apis.Sheets.v4.Data;
+using Microsoft.Extensions.Options;
+using Serilog;
+
+namespace QuizBowlDiscordScoreTracker.Scoresheet
+{
+    public sealed class GoogleSheetsApi : IGoogleSheetsApi
+    {
+        private static readonly Serilog.ILogger Logger = Log.ForContext(typeof(GoogleSheetsApi));
+        internal const int MaxRetries = 5;
+
+        public GoogleSheetsApi(IOptionsMonitor<BotConfiguration> options)
+        {
+            this.IsDisposed = false;
+            this.Options = options;
+
+            this.InitializeService();
+
+            this.OnConfigurationChangeHandler = this.Options.OnChange(this.OnConfigurationChange);
+        }
+
+        private bool IsDisposed { get; set; }
+
+        private IOptionsMonitor<BotConfiguration> Options { get; }
+
+        private IDisposable OnConfigurationChangeHandler { get; }
+
+        private SheetsService Service { get; set; }
+
+        public void Dispose()
+        {
+            if (this.IsDisposed)
+            {
+                this.Service?.Dispose();
+                this.OnConfigurationChangeHandler.Dispose();
+            }
+        }
+
+        public Task<IResult<string>> UpdateGoogleSheet(
+            List<ValueRange> ranges, List<string> rangesToClear, Uri sheetsUri)
+        {
+            Verify.IsNotNull(ranges, nameof(ranges));
+            Verify.IsNotNull(rangesToClear, nameof(rangesToClear));
+            Verify.IsNotNull(sheetsUri, nameof(sheetsUri));
+
+            return this.UpdateGoogleSheet(ranges, rangesToClear, sheetsUri, attemptedRetries: 0);
+        }
+
+        private void InitializeService()
+        {
+            string email = this.Options.CurrentValue.GoogleAppEmail;
+            if (email == null)
+            {
+                return;
+            }
+
+            string privateKey = this.Options.CurrentValue.GoogleAppPrivateKey;
+            if (privateKey == null)
+            {
+                return;
+            }
+
+            ServiceAccountCredential credential = new ServiceAccountCredential(
+               new ServiceAccountCredential.Initializer(email)
+               {
+                   Scopes = new[] { SheetsService.Scope.Spreadsheets }
+               }.FromPrivateKey(privateKey));
+
+            // If this takes time to initialize, we should make it Lazy
+            this.Service = new SheetsService(new BaseClientService.Initializer()
+            {
+                ApplicationName = "Quiz Bowl Score Tracker",
+                HttpClientInitializer = credential
+            });
+        }
+
+        private void OnConfigurationChange(BotConfiguration newConfiguration, string value)
+        {
+            SheetsService oldService = this.Service;
+            this.InitializeService();
+            oldService?.Dispose();
+        }
+
+        private async Task<IResult<string>> UpdateGoogleSheet(
+            List<ValueRange> ranges, List<string> rangesToClear, Uri sheetsUri, int attemptedRetries)
+        {
+            if (this.Service == null)
+            {
+                return new FailureResult<string>(
+                    "This instance of the bot doesn't support Google Sheets, because the Google account information for the bot isn't configured.");
+            }
+
+            IResult<string> sheetsIdResult = TryGetSheetsId(sheetsUri);
+            if (!sheetsIdResult.Success)
+            {
+                return sheetsIdResult;
+            }
+
+            string sheetsId = sheetsIdResult.Value;
+
+            try
+            {
+                BatchUpdateValuesRequest updateValuesData = new BatchUpdateValuesRequest()
+                {
+                    Data = ranges,
+                    ValueInputOption = "RAW"
+                };
+                SpreadsheetsResource.ValuesResource.BatchUpdateRequest batchUpdateRequest = new SpreadsheetsResource.ValuesResource.BatchUpdateRequest(
+                    this.Service, updateValuesData, sheetsId);
+
+                if (rangesToClear.Count > 0)
+                {
+                    BatchClearValuesRequest clearValuesData = new BatchClearValuesRequest()
+                    {
+                        Ranges = rangesToClear
+                    };
+                    SpreadsheetsResource.ValuesResource.BatchClearRequest clearRequest = new SpreadsheetsResource.ValuesResource.BatchClearRequest(
+                        this.Service, clearValuesData, sheetsId);
+                    await clearRequest.ExecuteAsync();
+                }
+
+                BatchUpdateValuesResponse batchUpdateResponse = await batchUpdateRequest.ExecuteAsync();
+                if (batchUpdateResponse.Responses.Any(response => response.UpdatedCells == 0))
+                {
+                    return new FailureResult<string>("Could only partially update the spreadsheet. Try again.");
+                }
+
+                return new SuccessResult<string>("Export successful");
+            }
+            catch (Google.GoogleApiException exception)
+            {
+                // See https://developers.google.com/drive/api/v3/handle-errors
+                int errorCode = exception.Error?.Code ?? 0;
+                if (errorCode == 403 &&
+                    exception.Error.Errors != null &&
+                    exception.Error.Errors.Any(error => error.Reason == "appNotAuthorizedToFile" || error.Reason == "forbidden" || error.Reason == "insufficientFilePermissions"))
+                {
+                    Logger.Error(exception, $"Error writing to the UCSD scoresheet: bot doesn't have permission");
+                    return new FailureResult<string>(
+                        $"The bot doesn't have write permissions to the Google Sheet. Please give `{this.Options.CurrentValue.GoogleAppEmail}` access to the Sheet by sharing it with them as an Editor.");
+                }
+                else if (attemptedRetries < MaxRetries && (errorCode == 403 || errorCode == 429))
+                {
+                    // Retry
+                    attemptedRetries++;
+                    Logger.Error(
+                        exception,
+                        $"Retry attempt {attemptedRetries} after getting a {errorCode} error for the UCSD scoresheet at the URL {sheetsUri.AbsoluteUri}");
+
+                    // Use exponential back-off: wait for 2 seconds, then 5, then 9, etc.
+                    await Task.Delay(1000 * (1 + (int)Math.Pow(2, attemptedRetries)));
+                    return await this.UpdateGoogleSheet(ranges, rangesToClear, sheetsUri, attemptedRetries);
+                }
+
+                // Log
+                Logger.Error(exception, $"Error writing to the UCSD scoresheet for URL {sheetsUri.AbsoluteUri}");
+                return new FailureResult<string>($"Error writing to the Google Sheet: \"{exception.Message}\"");
+            }
+        }
+
+        private static IResult<string> TryGetSheetsId(Uri sheetsUri)
+        {
+            // Format of a sheetsUrl: https://docs.google.com/spreadsheets/d/ID/edit#gid=87173672
+            if (sheetsUri.Segments.Length < 4)
+            {
+                return new FailureResult<string>(
+                    "The URL doesn't have the sheets ID in it. Be sure to copy the full URL from the address bar.");
+            }
+            else if (!sheetsUri.Segments[1].Equals("spreadsheets/", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return new FailureResult<string>(
+                    "The URL isn't for a spreadsheet. Be sure to copy the full URL from the address bar.");
+            }
+
+            string sheetsId = sheetsUri.Segments[3];
+            if (sheetsId.EndsWith("/", StringComparison.InvariantCultureIgnoreCase))
+            {
+                sheetsId = sheetsId.Substring(0, sheetsId.Length - 1);
+            }
+
+            return new SuccessResult<string>(sheetsId);
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Scoresheet/GoogleSheetsGeneratorFactory.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/GoogleSheetsGeneratorFactory.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace QuizBowlDiscordScoreTracker.Scoresheet
+{
+    public class GoogleSheetsGeneratorFactory : IGoogleSheetsGeneratorFactory
+    {
+        public GoogleSheetsGeneratorFactory(IGoogleSheetsApi sheetsApi)
+        {
+            this.SheetsApi = sheetsApi;
+        }
+
+        private IGoogleSheetsApi SheetsApi { get; }
+
+        public IGoogleSheetsGenerator Create(GoogleSheetsType sheetsType)
+        {
+            return sheetsType switch
+            {
+                GoogleSheetsType.UCSD => new UCSDGoogleSheetsGenerator(this.SheetsApi),
+                _ => throw new ArgumentException(
+$"Cannot create a generator for type {Enum.GetName(typeof(GoogleSheetsType), sheetsType)}"),
+            };
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Scoresheet/GoogleSheetsType.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/GoogleSheetsType.cs
@@ -1,0 +1,7 @@
+﻿namespace QuizBowlDiscordScoreTracker.Scoresheet
+{
+    public enum GoogleSheetsType
+    {
+        UCSD
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Scoresheet/IGoogleSheetsApi.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/IGoogleSheetsApi.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Google.Apis.Sheets.v4.Data;
+
+namespace QuizBowlDiscordScoreTracker.Scoresheet
+{
+    public interface IGoogleSheetsApi : IDisposable
+    {
+        /// <summary>
+        /// Clears the sheet, then updates it with new values. The cells in rangesToClear will be cleared before any
+        /// updates occur.
+        /// </summary>
+        /// <param name="ranges">The cells to update with their new values</param>
+        /// <param name="rangesToClear">The cells to clear</param>
+        /// <param name="sheetsUri">The URI to the Google Sheets workbook/param>
+        /// <returns></returns>
+        Task<IResult<string>> UpdateGoogleSheet(List<ValueRange> ranges, List<string> rangesToClear, Uri sheetsUri);
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Scoresheet/IGoogleSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/IGoogleSheetsGenerator.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading.Tasks;
+using QuizBowlDiscordScoreTracker.TeamManager;
+
+namespace QuizBowlDiscordScoreTracker.Scoresheet
+{
+    public interface IGoogleSheetsGenerator
+    {
+        // Future work:
+        // It would be great if we could do live scorekeeping, which requires going off of a timer
+        // Google APIs restrict us to 100 API calls per 100 seconds, so we need to do the following
+        // - Batch update
+        // - Take a diff between what's been updated, and what needs writing
+        //    - For this, might be best to have an event to call when we have scoring updates. This needs to include the
+        //      reverse for updates, so maybe just include phases that need to be rewritten?
+        // We can always do a pure "full export" first, then work on live updates
+        // Could have two interfaces for it: GoogleSheetFullGenerator, GoogleSheetPartialGenerator
+        // For the latter, we need a way to get the diffs
+
+        /// <summary>
+        /// Create the scoresheet for the game in the given Google Sheet worksheet
+        /// </summary>
+        /// <param name="game">Game to create the scoresheet from</param>
+        /// <param name="sheetsUri">URI to the Google Sheet with the worksheet for the tournament's rosters</param>
+        /// <param name="sheetName">Name of the worksheet for the round we're creating a scoresheet for</param>
+        /// <returns>A result with an error code if the update failed, or a result with an empty string on success</returns>
+        Task<IResult<string>> TryCreateScoresheet(GameState game, Uri sheetsUri, string sheetName);
+
+        /// <summary>
+        /// Updates the rosters spreadsheet in the Google Sheet
+        /// </summary>
+        /// <param name="teamManager">Team Manager used in the server or game.</param>
+        /// <param name="sheetsUri">URI to the Google Sheet with the worksheet for the tournament's rosters</param>
+        /// <returns>A result with an error code if the update failed, or a result with an empty string on success</returns>
+        Task<IResult<string>> TryUpdateRosters(ITeamManager teamManager, Uri sheetsUri);
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Scoresheet/IGoogleSheetsGeneratorFactory.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/IGoogleSheetsGeneratorFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace QuizBowlDiscordScoreTracker.Scoresheet
+{
+    public interface IGoogleSheetsGeneratorFactory
+    {
+        IGoogleSheetsGenerator Create(GoogleSheetsType sheetsType);
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Scoresheet/UCSDGoogleSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/UCSDGoogleSheetsGenerator.cs
@@ -1,0 +1,272 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Google.Apis.Sheets.v4.Data;
+using QuizBowlDiscordScoreTracker.TeamManager;
+
+namespace QuizBowlDiscordScoreTracker.Scoresheet
+{
+    // TODO: Eventually allow for more columns than Z (can even just do up to ZZ: +500 unrealistic for QB)
+    // TODO: Add reader name to mod/scorekeeper section
+
+    public sealed class UCSDGoogleSheetsGenerator : IGoogleSheetsGenerator
+    {
+        internal const int FirstPhaseRow = 4;
+        internal const int PlayersPerTeamLimit = 6;
+        internal const int PhasesLimit = 28;
+        internal const int LastBonusRow = 27;
+        internal const string RostersSheetName = "Rosters";
+        internal static readonly ReadOnlyMemory<char> StartingColumnsChars = new char[] { 'C', 'O' };
+
+        private const int TeamNameRow = 1;
+        private const int PlayerNameRow = 3;
+
+        private static readonly char[] BonusColumns = new char[] { 'I', 'U' };
+        private static readonly bool[] ClearedBonusArray = new bool[] { false, false, false };
+
+        private static readonly List<string> ClearRosters = new List<string>() { $"'{RostersSheetName}'!A2:G999" };
+
+        public UCSDGoogleSheetsGenerator(IGoogleSheetsApi sheetsApi)
+        {
+            this.SheetsApi = sheetsApi;
+        }
+
+        private IGoogleSheetsApi SheetsApi { get; }
+
+        public async Task<IResult<string>> TryCreateScoresheet(GameState game, Uri sheetsUri, string sheetName)
+        {
+            Verify.IsNotNull(game, nameof(game));
+            Verify.IsNotNull(sheetsUri, nameof(sheetsUri));
+
+            // TODO: Initializing the team and player mappings is the same as ExcleFileScoresheetGenerator. See if we
+            // can unify this, if the abstractions make sense.
+            IReadOnlyDictionary<string, string> teamIdToNames = await game.TeamManager.GetTeamIdToNames();
+            if (teamIdToNames.Count == 0 || teamIdToNames.Count > 2)
+            {
+                return CreateFailureResult("Export only works if there are 1 or 2 teams in the game.");
+            }
+
+            // Make it an array so we don't keep re-evaluating the enumerable
+            PlayerTeamPair[] players = (await game.TeamManager.GetKnownPlayers()).ToArray();
+            IEnumerable<IGrouping<string, PlayerTeamPair>> playersByTeam = players.GroupBy(player => player.TeamId);
+            if (playersByTeam.Any(grouping => grouping.Count() > PlayersPerTeamLimit))
+            {
+                return CreateFailureResult("Export only currently works if there are at most 6 players on a team.");
+            }
+
+            string[] teamIds = playersByTeam.Select(grouping => grouping.Key).ToArray();
+
+            // We could have an extra phase, but if there are no scoring actions, then it wasn't played
+            IEnumerable<PhaseScore> phaseScores = await game.GetPhaseScores();
+            int phaseScoresCount = phaseScores.Count();
+            if (phaseScoresCount > PhasesLimit + 1 ||
+                (phaseScoresCount == PhasesLimit + 1 && phaseScores.Last().ScoringSplitsOnActions.Any()))
+            {
+                return CreateFailureResult(
+                    $"Export only currently works if there are at most {PhasesLimit} tosusps answered in a game. Bonuses will only be tracked up to question 24.");
+            }
+
+            // TODO: When Formats are supported (so bonuses stop after a certain number of questions), support the
+            // tiebreakers.
+
+            IReadOnlyDictionary<ulong, char> playerIdToColumn = CreatePlayerIdToColumnMapping(playersByTeam);
+
+            // TODO: See if filling in player's scores by columns can be done efficiently, since it should require less
+            // requests
+            List<ValueRange> ranges = new List<ValueRange>
+            {
+                CreateUpdateSingleCellRequest(
+                    sheetName, StartingColumnsChars.Span[0], TeamNameRow, teamIdToNames[playersByTeam.First().Key])
+            };
+            if (teamIdToNames.Count > 1)
+            {
+                ranges.Add(CreateUpdateSingleCellRequest(
+                    sheetName, StartingColumnsChars.Span[1], TeamNameRow, teamIdToNames[playersByTeam.ElementAt(1).Key]));
+            }
+
+            foreach (PlayerTeamPair pair in players)
+            {
+                // TODO: Make this more efficient by putting all the player names in one update request
+                char column = playerIdToColumn[pair.PlayerId];
+                ranges.Add(CreateUpdateSingleCellRequest(sheetName, column, PlayerNameRow, pair.PlayerDisplayName));
+            }
+
+            int row = FirstPhaseRow;
+            List<char> scoredColumns = new List<char>();
+            foreach (PhaseScore phaseScore in phaseScores)
+            {
+                foreach (ScoringSplitOnScoreAction action in phaseScore.ScoringSplitsOnActions)
+                {
+                    if (!playerIdToColumn.TryGetValue(action.Action.Buzz.UserId, out char column))
+                    {
+                        return new FailureResult<string>(
+                            $"Unknown player {action.Action.Buzz.PlayerDisplayName} (ID {action.Action.Buzz.UserId}). Cannot accurately create a scoresheet. This happens in phase {row - FirstPhaseRow + 1}");
+                    }
+
+                    ranges.Add(CreateUpdateSingleCellRequest(sheetName, column, row, action.Action.Score));
+                    scoredColumns.Add(column);
+                }
+
+                scoredColumns.Clear();
+
+                if (row <= LastBonusRow)
+                {
+                    if (phaseScore.BonusScores?.Any() == true)
+                    {
+                        int bonusPartCount = phaseScore.BonusScores.Count();
+                        if (bonusPartCount != 3)
+                        {
+                            return new FailureResult<string>(
+                                $"Non-three part bonus in phase {row - FirstPhaseRow + 1}. Number of parts: {bonusPartCount}. These aren't supported for the scoresheet.");
+                        }
+
+                        int bonusScoresIndex = Array.IndexOf(teamIds, phaseScore.BonusTeamId);
+                        if (bonusScoresIndex < 0)
+                        {
+                            return new FailureResult<string>(
+                                $"Unknown bonus team in phase {row - FirstPhaseRow + 1}. Cannot accurately create a scoresheet.");
+                        }
+
+                        char bonusColumn = BonusColumns[bonusScoresIndex];
+                        ranges.Add(CreateUpdateCellsAlongRowRequest(
+                            sheetName, bonusColumn, row, phaseScore.BonusScores.Select(score => score > 0).ToArray()));
+
+                        char otherBonusColumn = BonusColumns[BonusColumns.Length - bonusScoresIndex - 1];
+                        ranges.Add(CreateUpdateCellsAlongRowRequest(
+                            sheetName, otherBonusColumn, row, ClearedBonusArray));
+                    }
+                    else
+                    {
+                        // Clear the bonus columns
+                        foreach (char column in BonusColumns)
+                        {
+                            ranges.Add(CreateUpdateCellsAlongRowRequest(sheetName, column, row, ClearedBonusArray));
+                        }
+                    }
+                }
+
+                row++;
+            }
+
+            int columnsAfterInitial = PlayersPerTeamLimit - 1;
+            List<string> rangesToClear = new List<string>()
+            {
+                // Add 5 to the column because the sheet supports 6 players. The first column counts as the first
+                // player already.
+                $"'{sheetName}'!{StartingColumnsChars.Span[0]}4:{(char)(StartingColumnsChars.Span[0] + columnsAfterInitial)}31",
+                $"'{sheetName}'!{StartingColumnsChars.Span[1]}4:{(char)(StartingColumnsChars.Span[1] + columnsAfterInitial)}31",
+            };
+
+            return await this.SheetsApi.UpdateGoogleSheet(ranges, rangesToClear, sheetsUri);
+        }
+
+        public async Task<IResult<string>> TryUpdateRosters(ITeamManager teamManager, Uri sheetsUri)
+        {
+            Verify.IsNotNull(teamManager, nameof(teamManager));
+            Verify.IsNotNull(sheetsUri, nameof(sheetsUri));
+
+            IReadOnlyDictionary<string, string> teamIdToNames = await teamManager.GetTeamIdToNames();
+
+            IEnumerable<PlayerTeamPair> playerTeamPairs = await teamManager.GetKnownPlayers();
+            IEnumerable<IGrouping<string, PlayerTeamPair>> groupings = playerTeamPairs
+                .GroupBy(pair => pair.TeamId)
+                .Where(grouping => grouping.Any());
+
+            if (groupings.Any(grouping => grouping.Count() > PlayersPerTeamLimit))
+            {
+                return CreateFailureResult("Rosters can only support up to 6 players per team.");
+            }
+
+            int row = 2;
+            List<ValueRange> ranges = new List<ValueRange>();
+            foreach (IGrouping<string, PlayerTeamPair> grouping in groupings)
+            {
+                PlayerTeamPair firstPair = grouping.First();
+                if (!teamIdToNames.TryGetValue(firstPair.TeamId, out string teamName))
+                {
+                    // It's not a team, but an individual player. Use their name.
+                    teamName = firstPair.PlayerDisplayName;
+                }
+
+                IEnumerable<string> playerNames = grouping.Select(pair => pair.PlayerDisplayName);
+                IEnumerable<string> rowValues = new string[] { teamName }
+                    .Concat(playerNames);
+                ranges.Add(CreateUpdateCellsAlongRowRequest(RostersSheetName, 'A', row, rowValues));
+
+                row++;
+            }
+
+            // Go through the teams and update rosters
+            return await this.SheetsApi.UpdateGoogleSheet(ranges, ClearRosters, sheetsUri);
+        }
+
+        private static FailureResult<string> CreateFailureResult(string errorMessage)
+        {
+            return new FailureResult<string>($"Couldn't write to the sheet. {errorMessage}");
+        }
+
+        // This is similar to the one in ExcelFileScoresheetGenerator, but it works on
+        private static IReadOnlyDictionary<ulong, char> CreatePlayerIdToColumnMapping(
+            IEnumerable<IGrouping<string, PlayerTeamPair>> playersByTeam)
+        {
+            Dictionary<ulong, char> playerIdToColumn = new Dictionary<ulong, char>();
+            int startingColumnIndex = 0;
+            foreach (IGrouping<string, PlayerTeamPair> grouping in playersByTeam)
+            {
+                char startingColumn = StartingColumnsChars.Span[startingColumnIndex];
+                foreach (PlayerTeamPair pair in grouping)
+                {
+                    // TODO: If we ever support more than 6 players, we should bump up the next starting column
+                    playerIdToColumn[pair.PlayerId] = startingColumn++;
+                }
+
+                startingColumnIndex++;
+            }
+
+            return playerIdToColumn;
+        }
+
+        // TODO: If the sheet ever supports columns past Z, we need to use a string or wrapper class for AA and above
+        private static ValueRange CreateUpdateSingleCellRequest<T>(string sheetName, char column, int rowIndex, T value)
+        {
+            ValueRange range = new ValueRange()
+            {
+                Range = $"'{sheetName}'!{column}{rowIndex}",
+                Values = new List<IList<object>>()
+                {
+                    new List<object>()
+                    {
+                        value
+                    }
+                }
+            };
+
+            return range;
+        }
+
+        // TODO: If the sheet ever supports columns past Z, we need to use a string or wrapper class for AA and above
+        private static ValueRange CreateUpdateCellsAlongRowRequest<T>(
+            string sheetName, char column, int rowIndex, IEnumerable<T> values)
+        {
+            // Subtract one, since the start column already covers the first value
+            char endColumn = (char)(column + values.Count() - 1);
+            List<object> innerList = new List<object>();
+            foreach (T value in values)
+            {
+                innerList.Add(value);
+            }
+
+            ValueRange range = new ValueRange()
+            {
+                Range = $"'{sheetName}'!{column}{rowIndex}:{endColumn}{rowIndex}",
+                Values = new List<IList<object>>()
+                {
+                    innerList
+                }
+            };
+
+            return range;
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTrackerUnitTests/GeneralCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/GeneralCommandHandlerTests.cs
@@ -1423,7 +1423,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             Assert.IsTrue(teamManager.TryAddTeam(FirstTeamName, out _), "Couldn't add team");
 
             Assert.IsNull(await teamManager.GetTeamIdOrNull(userId), "User shouldn't be on a team yet");
-            string upperFirstTeamName = FirstTeamName.ToUpper();
+            string upperFirstTeamName = FirstTeamName.ToUpper(CultureInfo.InvariantCulture);
             await this.Handler.JoinTeamAsync(upperFirstTeamName);
             Assert.AreEqual(FirstTeamName, await teamManager.GetTeamIdOrNull(userId), "User didn't join the team");
             this.MessageStore.VerifyChannelMessages($@"@User_{userId} is on team ""{FirstTeamName}""");

--- a/QuizBowlDiscordScoreTrackerUnitTests/UCSDGoogleSheetsGeneratorTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/UCSDGoogleSheetsGeneratorTests.cs
@@ -1,0 +1,445 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Google.Apis.Sheets.v4.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using QuizBowlDiscordScoreTracker;
+using QuizBowlDiscordScoreTracker.Scoresheet;
+using QuizBowlDiscordScoreTracker.TeamManager;
+
+namespace QuizBowlDiscordScoreTrackerUnitTests
+{
+    [TestClass]
+    public class UCSDGoogleSheetsGeneratorTests
+    {
+        private const string FirstTeam = "Alpha";
+        private const string SecondTeam = "Beta";
+        private const string SheetName = "Round 1";
+
+        private static readonly Uri SheetsUri = new Uri("http://localhost/sheets/sheetsId/");
+
+        private List<string> ClearedRanges { get; set; }
+
+        private UCSDGoogleSheetsGenerator Generator { get; set; }
+
+        private ByCommandTeamManager TeamManager { get; set; }
+
+        private List<UpdateRange> UpdatedRanges { get; set; }
+
+        [TestInitialize]
+        public void InitializeTest()
+        {
+            // Clear out the old fields
+            this.UpdatedRanges = new List<UpdateRange>();
+            this.ClearedRanges = new List<string>();
+            this.TeamManager = new ByCommandTeamManager();
+
+            IGoogleSheetsApi googleSheetsApi = this.CreateGoogleSheetsApi();
+            this.Generator = new UCSDGoogleSheetsGenerator(googleSheetsApi);
+        }
+
+        [TestMethod]
+        public async Task SetRostersSucceeds()
+        {
+            this.TeamManager.TryAddTeam(FirstTeam, out _);
+            this.TeamManager.TryAddTeam(SecondTeam, out _);
+            this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam);
+            this.TeamManager.TryAddPlayerToTeam(3, "Alan", FirstTeam);
+            this.TeamManager.TryAddPlayerToTeam(4, "Bob", SecondTeam);
+
+            IResult<string> result = await this.Generator.TryUpdateRosters(this.TeamManager, SheetsUri);
+            Assert.IsTrue(result.Success, "Update should've succeeded");
+
+            Assert.AreEqual(1, this.ClearedRanges.Count, "Unexpected number of clears");
+            Assert.AreEqual($"'{UCSDGoogleSheetsGenerator.RostersSheetName}'!A2:G999", this.ClearedRanges[0], "Unexpected range");
+
+            Assert.AreEqual(2, this.UpdatedRanges.Count, "");
+
+            UpdateRange updateRange = this.UpdatedRanges[0];
+            Assert.AreEqual(
+                $"'{UCSDGoogleSheetsGenerator.RostersSheetName}'!A2:C2",
+                updateRange.Range,
+                "Unexpected range for the first team");
+            CollectionAssert.AreEquivalent(
+                new string[] { FirstTeam, "Alice", "Alan" },
+                updateRange.Values.ToArray(),
+                "Unexpected row for the first team");
+
+            updateRange = this.UpdatedRanges[1];
+            Assert.AreEqual(
+                $"'{UCSDGoogleSheetsGenerator.RostersSheetName}'!A3:B3",
+                updateRange.Range,
+                "Unexpected range for the second team");
+            CollectionAssert.AreEquivalent(
+                new string[] { SecondTeam, "Bob" },
+                updateRange.Values.ToArray(),
+                "Unexpected row for the second team");
+        }
+
+        [TestMethod]
+        public async Task SetRostersFailsWithMoreThanSixPlayers()
+        {
+            this.TeamManager.TryAddTeam(FirstTeam, out _);
+            for (int i = 0; i < 6; i++)
+            {
+                this.TeamManager.TryAddPlayerToTeam((ulong)i, $"{i}", FirstTeam);
+            }
+
+            IResult<string> result = await this.Generator.TryUpdateRosters(this.TeamManager, SheetsUri);
+            Assert.IsTrue(result.Success, $"Update should've succeeded at the limit.");
+
+            Assert.IsTrue(
+                this.TeamManager.TryAddPlayerToTeam(1111, "OverLimit", FirstTeam),
+                "Adding the player over the limit should've succeeded");
+            result = await this.Generator.TryUpdateRosters(this.TeamManager, SheetsUri);
+            Assert.IsFalse(result.Success, $"Update should've failed after the limit.");
+            Assert.AreEqual(
+                $"Couldn't write to the sheet. Rosters can only support up to {UCSDGoogleSheetsGenerator.PlayersPerTeamLimit} players per team.",
+                result.ErrorMessage,
+                "Unexpected error message");
+        }
+
+        [TestMethod]
+        public async Task TryCreateScoresheetSucceeds()
+        {
+            // Do something simple, then read the spreadsheet and verify some fields
+            GameState game = new GameState()
+            {
+                Format = Format.TossupBonusesShootout,
+                ReaderId = 1,
+                TeamManager = this.TeamManager
+            };
+
+            this.TeamManager.TryAddTeam(FirstTeam, out _);
+            this.TeamManager.TryAddTeam(SecondTeam, out _);
+            this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam);
+            this.TeamManager.TryAddPlayerToTeam(3, "Alan", FirstTeam);
+            this.TeamManager.TryAddPlayerToTeam(4, "Bob", SecondTeam);
+
+            await game.AddPlayer(2, "Alice");
+            game.ScorePlayer(15);
+            game.TryScoreBonus("10/0/10");
+
+            await game.AddPlayer(3, "Alan");
+            game.ScorePlayer(-5);
+            await game.AddPlayer(4, "Bob");
+            game.ScorePlayer(10);
+            game.TryScoreBonus("0/10/0");
+
+            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, SheetName);
+            Assert.IsTrue(result.Success, $"Failed: {(result.Success ? "" : result.ErrorMessage)}");
+
+            // Assert we cleared these two fields
+            Assert.IsTrue(this.ClearedRanges.Contains("'Round 1'!C4:H31"), "First team scores are not in the list of cleared ranges.");
+            Assert.IsTrue(this.ClearedRanges.Contains("'Round 1'!O4:T31"), "Second team scores are not in the list of cleared ranges.");
+
+            // These checks are O(n^2), since we do Any for all of them. However, n is small here (~15), so it's not
+            // too bad.
+
+            // Team names
+            this.AssertInUpdateRange("'Round 1'!C1", FirstTeam, "Couldn't find first team");
+            this.AssertInUpdateRange("'Round 1'!O1", SecondTeam, "Couldn't find second team");
+
+            // Player names
+            this.AssertInUpdateRange("'Round 1'!C3", "Alice", "Couldn't find Alice");
+            this.AssertInUpdateRange("'Round 1'!D3", "Alan", "Couldn't find Alan");
+            this.AssertInUpdateRange("'Round 1'!O3", "Bob", "Couldn't find Bob");
+
+            // Tossups
+            this.AssertInUpdateRange("'Round 1'!C4", "15", "Couldn't find Alice's buzz");
+            this.AssertInUpdateRange("'Round 1'!D5", "-5", "Couldn't find Alan's buzz");
+            this.AssertInUpdateRange("'Round 1'!O5", "10", "Couldn't find Bob's buzz");
+
+            // Bonuses
+            UpdateRange updateRange = this.UpdatedRanges
+                .FirstOrDefault(valueRange => valueRange.Range == "'Round 1'!I4:K4");
+            Assert.IsNotNull(updateRange, "Couldn't find range for the first bonus");
+            CollectionAssert.AreEquivalent(
+                new bool[] { true, false, true },
+                updateRange.Values.ToArray(),
+                "Unexpected scoring for the first bonus");
+
+            updateRange = this.UpdatedRanges
+                .FirstOrDefault(valueRange => valueRange.Range == "'Round 1'!U5:W5");
+            Assert.IsNotNull(updateRange, "Couldn't find range for the second bonus");
+            CollectionAssert.AreEquivalent(
+                new bool[] { false, true, false },
+                updateRange.Values.ToArray(),
+                "Unexpected scoring for the second bonus");
+        }
+
+        [TestMethod]
+        public async Task TryCreateScoresheetAtPlayerLimitSucceeds()
+        {
+            GameState game = new GameState()
+            {
+                Format = Format.TossupShootout,
+                ReaderId = 1,
+                TeamManager = this.TeamManager
+            };
+
+            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the first team");
+            Assert.IsTrue(this.TeamManager.TryAddTeam(SecondTeam, out _), "Couldn't add the second team");
+
+            for (int i = 0; i < UCSDGoogleSheetsGenerator.PlayersPerTeamLimit; i++)
+            {
+                Assert.IsTrue(
+                    this.TeamManager.TryAddPlayerToTeam((ulong)i + 2, $"FirstPlayer{i}", FirstTeam),
+                    $"Couldn't add player #{i} to the first team");
+                Assert.IsTrue(
+                    this.TeamManager.TryAddPlayerToTeam((ulong)i + 200, $"SecondPlayer{i}", SecondTeam),
+                    $"Couldn't add player #{i} to the second team");
+            }
+
+            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, SheetName);
+            Assert.IsTrue(result.Success, $"Creation should've succeeded at the limit.");
+
+            char firstTeamColumn = UCSDGoogleSheetsGenerator.StartingColumnsChars.Span[0];
+            char secondTeamColumn = UCSDGoogleSheetsGenerator.StartingColumnsChars.Span[1];
+            for (int i = 0; i < UCSDGoogleSheetsGenerator.PlayersPerTeamLimit; i++)
+            {
+                this.AssertInUpdateRange(
+                    $"'Round 1'!{firstTeamColumn}3",
+                    $"FirstPlayer{i}",
+                    $"Couldn't find the player { i + 1 } on the first team");
+                this.AssertInUpdateRange(
+                    $"'Round 1'!{secondTeamColumn}3",
+                    $"SecondPlayer{i}",
+                    $"Couldn't find player {i + 1} on the second team");
+                firstTeamColumn++;
+                secondTeamColumn++;
+            }
+        }
+
+        [TestMethod]
+        public async Task TryCreateScoresheetAtPhasesLimitSucceeds()
+        {
+            GameState game = new GameState()
+            {
+                Format = Format.TossupBonusesShootout,
+                ReaderId = 1,
+                TeamManager = this.TeamManager
+            };
+
+            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the first team");
+            Assert.IsTrue(this.TeamManager.TryAddTeam(SecondTeam, out _), "Couldn't add the second team");
+            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam), "Couldn't add first player to team");
+            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(3, "Bob", SecondTeam), "Couldn't add second player to team");
+
+            for (int i = 0; i < UCSDGoogleSheetsGenerator.PhasesLimit - 1; i++)
+            {
+                await game.AddPlayer(2, "Alice");
+                game.ScorePlayer(10);
+                Assert.IsTrue(game.TryScoreBonus("0"), $"Scoring a bonus should've succeeded in phase {i}");
+            }
+
+            await game.AddPlayer(3, "Bob");
+            game.ScorePlayer(-5);
+            await game.AddPlayer(2, "Alice");
+            game.ScorePlayer(15);
+
+            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, SheetName);
+            Assert.IsTrue(result.Success, $"Creation should've succeeded at the limit.");
+
+            int lastRow = UCSDGoogleSheetsGenerator.FirstPhaseRow + UCSDGoogleSheetsGenerator.PhasesLimit - 1;
+            this.AssertInUpdateRange($"'Round 1'!C{lastRow}", "15", "Couldn't find Alice's buzz");
+            this.AssertInUpdateRange($"'Round 1'!O{lastRow}", "-5", "Couldn't find Bob's buzz");
+        }
+
+        [TestMethod]
+        public async Task NoBonusesWrittenAfterBonusLimit()
+        {
+            GameState game = new GameState()
+            {
+                Format = Format.TossupBonusesShootout,
+                ReaderId = 1,
+                TeamManager = this.TeamManager
+            };
+
+            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the first team");
+            Assert.IsTrue(this.TeamManager.TryAddTeam(SecondTeam, out _), "Couldn't add the second team");
+            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam), "Couldn't add first player to team");
+            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(3, "Bob", SecondTeam), "Couldn't add second player to team");
+
+            int lastBonusPhase = UCSDGoogleSheetsGenerator.LastBonusRow - UCSDGoogleSheetsGenerator.FirstPhaseRow;
+            for (int i = 0; i < lastBonusPhase; i++)
+            {
+                await game.AddPlayer(2, "Alice");
+                game.ScorePlayer(10);
+                Assert.IsTrue(game.TryScoreBonus("0"), $"Scoring a bonus should've succeeded in phase {i}");
+            }
+
+            await game.AddPlayer(2, "Alice");
+            game.ScorePlayer(15);
+            Assert.IsTrue(game.TryScoreBonus("30"), $"Scoring a bonus should've succeeded in the last phase");
+
+            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, SheetName);
+            Assert.IsTrue(result.Success, $"Creation should've succeeded at the limit.");
+
+            UpdateRange updateRange = this.UpdatedRanges
+                .FirstOrDefault(valueRange => valueRange.Range == $"'Round 1'!I{UCSDGoogleSheetsGenerator.LastBonusRow}:K{UCSDGoogleSheetsGenerator.LastBonusRow}");
+            Assert.IsNotNull(updateRange, "Couldn't find range for the last bonus");
+            CollectionAssert.AreEquivalent(
+                new bool[] { true, true, true },
+                updateRange.Values.ToArray(),
+                "Unexpected scoring for the last bonus");
+
+            updateRange = this.UpdatedRanges
+                .FirstOrDefault(valueRange => valueRange.Range == $"'Round 1'!I{UCSDGoogleSheetsGenerator.LastBonusRow + 1}:K{UCSDGoogleSheetsGenerator.LastBonusRow + 1}");
+            Assert.IsNull(updateRange, "Bonus past the last bonus phase should'nt be exported");
+        }
+
+        [TestMethod]
+        public async Task TryCreateScoresheetPastPlayerLimitFails()
+        {
+            GameState game = new GameState()
+            {
+                Format = Format.TossupShootout,
+                ReaderId = 1,
+                TeamManager = this.TeamManager
+            };
+
+            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the first team");
+            Assert.IsTrue(this.TeamManager.TryAddTeam(SecondTeam, out _), "Couldn't add the second team");
+
+            for (int i = 0; i < UCSDGoogleSheetsGenerator.PlayersPerTeamLimit; i++)
+            {
+                Assert.IsTrue(
+                    this.TeamManager.TryAddPlayerToTeam((ulong)i + 2, $"Player{i}", FirstTeam),
+                    $"Couldn't add player #{i} to the first team");
+                Assert.IsTrue(
+                    this.TeamManager.TryAddPlayerToTeam((ulong)i + 200, $"Player{i}", SecondTeam),
+                    $"Couldn't add player #{i} to the second team");
+            }
+
+            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, SheetName);
+            Assert.IsTrue(result.Success, $"Creation should've succeeded at the limit.");
+
+            Assert.IsTrue(
+                this.TeamManager.TryAddPlayerToTeam(1111, "OverLimit", FirstTeam),
+                "Adding the player over the limit should've succeeded");
+            result = await this.Generator.TryCreateScoresheet(game, SheetsUri, SheetName);
+            Assert.IsFalse(result.Success, $"Creation should've failed after the limit.");
+            Assert.AreEqual(
+                $"Couldn't write to the sheet. Export only currently works if there are at most {UCSDGoogleSheetsGenerator.PlayersPerTeamLimit} players on a team.",
+                result.ErrorMessage,
+                "Unexpected error message");
+        }
+
+        [TestMethod]
+        public async Task TryCreateScoresheetPastPhaseLimitFails()
+        {
+            GameState game = new GameState()
+            {
+                Format = Format.TossupShootout,
+                ReaderId = 1,
+                TeamManager = this.TeamManager
+            };
+
+            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the team");
+            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam), "Couldn't add player to team");
+
+            for (int i = 0; i < UCSDGoogleSheetsGenerator.PhasesLimit; i++)
+            {
+                await game.AddPlayer(2, "Alice");
+                game.ScorePlayer(10);
+            }
+
+            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, SheetName);
+            Assert.IsTrue(result.Success, $"Creation should've succeeded at the limit.");
+
+            await game.AddPlayer(2, "Alice");
+            game.ScorePlayer(10);
+            result = await this.Generator.TryCreateScoresheet(game, SheetsUri, SheetName);
+            Assert.IsFalse(result.Success, $"Creation should've failed after the limit.");
+            Assert.AreEqual(
+                $"Couldn't write to the sheet. Export only currently works if there are at most {UCSDGoogleSheetsGenerator.PhasesLimit} tosusps answered in a game. Bonuses will only be tracked up to question 24.",
+                result.ErrorMessage,
+                "Unexpected error message");
+        }
+
+        [TestMethod]
+        public async Task TryCreateScoresheetWithoutTeamsFails()
+        {
+            GameState game = new GameState()
+            {
+                Format = Format.TossupBonusesShootout,
+                ReaderId = 1,
+                TeamManager = this.TeamManager
+            };
+
+            await game.AddPlayer(2, "Alice");
+            game.ScorePlayer(10);
+
+            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, SheetName);
+            Assert.IsFalse(result.Success, $"Creation succeeded when it should've failed.");
+            Assert.AreEqual(
+                "Couldn't write to the sheet. Export only works if there are 1 or 2 teams in the game.",
+                result.ErrorMessage,
+                "Unexpected error message");
+        }
+
+        [TestMethod]
+        public async Task TryCreateScoresheetWithMoreThanTwoTeamsFails()
+        {
+            GameState game = new GameState()
+            {
+                Format = Format.TossupBonusesShootout,
+                ReaderId = 1,
+                TeamManager = this.TeamManager
+            };
+
+            for (int i = 0; i < 3; i++)
+            {
+                string teamName = $"Team{i}";
+                Assert.IsTrue(this.TeamManager.TryAddTeam(teamName, out _), $"Couldn't add team {teamName}");
+            }
+
+            await game.AddPlayer(2, "Alice");
+            game.ScorePlayer(10);
+
+            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, SheetName);
+            Assert.IsFalse(result.Success, $"Creation succeeded when it should've failed.");
+            Assert.AreEqual(
+                "Couldn't write to the sheet. Export only works if there are 1 or 2 teams in the game.",
+                result.ErrorMessage,
+                "Unexpected error message");
+        }
+
+        private void AssertInUpdateRange(string range, string value, string message)
+        {
+            Assert.IsTrue(
+                this.UpdatedRanges
+                    .Any(valueRange => valueRange.Range == range && valueRange.Values.Any(v => v.ToString() == value)),
+                message);
+        }
+
+        private IGoogleSheetsApi CreateGoogleSheetsApi()
+        {
+            Mock<IGoogleSheetsApi> mockGoogleSheetsApi = new Mock<IGoogleSheetsApi>();
+            mockGoogleSheetsApi
+                .Setup(api => api.UpdateGoogleSheet(It.IsAny<List<ValueRange>>(), It.IsAny<List<string>>(), It.IsAny<Uri>()))
+                .Returns<List<ValueRange>, List<string>, Uri>((updateRanges, clearRanges, sheetsUri) =>
+                {
+                    this.UpdatedRanges.AddRange(updateRanges.Select(range =>
+                        new UpdateRange()
+                        {
+                            Range = range.Range,
+                            Values = range.Values.Count > 0 ? range.Values[0] : new List<object>()
+                        }));
+                    this.ClearedRanges.AddRange(clearRanges);
+                    return Task.FromResult<IResult<string>>(new SuccessResult<string>(string.Empty));
+                });
+            return mockGoogleSheetsApi.Object;
+        }
+
+        private class UpdateRange
+        {
+            public string Range { get; set; }
+
+            public IList<object> Values { get; set; }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is a Discord bot which keeps track of who buzzed in, as well as each player
 - You can type !score to get the current scores
 - If the reader needs to undo their last scoring action, use !undo
 - If you want to change readers, use !setnewreader @NewReadersMention
+- If you want to export the results to a scoresheet, use one of the export commands, like !exportToFile
 - When you're done reading, type !end
 - To see the list of all the commands, type !help
 


### PR DESCRIPTION
- Add support for exporting scores to a UCSD Sheets instance. You can set the rosters with !setRostersForUCSD and export the results to a scoresheet with !exportToUCSD
    - Using this requires two new configuration parameters in config.txt:
        - googleAppJsonFile tells the bot where the JSON configuration for the service credential is, so it can read the email and private key it needs to make API calls
- #61 Don't send message in guild unless it has permissions
- #62 Don't mute readers if the bot doesn't have permission
- Fix bug where game was created for reader who didn't have the role when ReaderRolePrefix was set
- Fix bug where the reader couldn't export if they were reading the last bonus allowed