### PR TITLE
Merged PR 141: Version 3.7.0 (TJSheets support)

### DIFF
--- a/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
@@ -3,7 +3,6 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
-using Microsoft.Extensions.Options;
 using QuizBowlDiscordScoreTracker.Database;
 using QuizBowlDiscordScoreTracker.Scoresheet;
 
@@ -14,11 +13,8 @@ namespace QuizBowlDiscordScoreTracker.Commands
     public class AdminCommands : ModuleBase
     {
         public AdminCommands(
-            IOptionsMonitor<BotConfiguration> options,
-            IDatabaseActionFactory dbActionFactory,
-            IGoogleSheetsGeneratorFactory googleSheetsGeneratorFactory)
+            IDatabaseActionFactory dbActionFactory, IGoogleSheetsGeneratorFactory googleSheetsGeneratorFactory)
         {
-            this.Options = options;
             this.DatabaseActionFactory = dbActionFactory;
             this.GoogleSheetsGeneratorFactory = googleSheetsGeneratorFactory;
         }
@@ -26,8 +22,6 @@ namespace QuizBowlDiscordScoreTracker.Commands
         private IDatabaseActionFactory DatabaseActionFactory { get; }
 
         private IGoogleSheetsGeneratorFactory GoogleSheetsGeneratorFactory { get; }
-
-        private IOptionsMonitor<BotConfiguration> Options { get; }
 
         [Command("checkPermissions")]
         [Summary("Checks if the bot has all the required permissions. " +
@@ -118,6 +112,17 @@ namespace QuizBowlDiscordScoreTracker.Commands
         }
 
         [HumanOnly]
+        [Command("setRostersForTJ")]
+        [Summary("Sets the rosters for the Rosters sheet for TJ Sheets.")]
+        [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings",
+            Justification = "Discord.Net can't parse the argument directly as a URI")]
+        public Task SetRostersFromRolesForTJ(
+            [Summary("The URL to the TJ Rosters Google Sheet. For example, https://docs.google.com/spreadsheets/d/1dZ_Yj_WBt5nWoHdyhv2VYeW--ecNR8-aQY39TBsaNwU")] string sheetsUrl)
+        {
+            return this.GetHandler().SetRostersFromRolesForTJ(sheetsUrl);
+        }
+
+        [HumanOnly]
         [Command("setRostersForUCSD")]
         [Summary("Sets the rosters for the Rosters sheet for the UCSD scoresheets.")]
         [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings",
@@ -149,8 +154,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
         private AdminCommandHandler GetHandler()
         {
             // this.Context is null in the constructor, so create the handler in this method
-            return new AdminCommandHandler(
-                this.Context, this.Options, this.DatabaseActionFactory, this.GoogleSheetsGeneratorFactory);
+            return new AdminCommandHandler(this.Context, this.DatabaseActionFactory, this.GoogleSheetsGeneratorFactory);
         }
     }
 }

--- a/QuizBowlDiscordScoreTracker/Commands/ReaderCommands.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/ReaderCommands.cs
@@ -110,13 +110,26 @@ namespace QuizBowlDiscordScoreTracker.Commands
         }
 
         [HumanOnly]
+        [Command("exportToTJ")]
+        [Summary("Exports the scoresheet to the UCSD Scoresheet. Export requires that one or two teams are " +
+            "playing, that each team has at most 6 players, and that at most 24 tossups have been played.")]
+        [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings",
+            Justification = "Discord.Net can't parse the argument directly as a URI")]
+        public Task ExportToTJAsync(
+            [Summary("The URL to the TJ Google Sheet. For example, https://docs.google.com/spreadsheets/d/1IJji0c23_mOYz6SnMiUlj2WDCIAHutIqfMdG-0hpEIU")] string sheetsUrl,
+            [Summary("The round number, starting from 1")][Remainder] int round)
+        {
+            return this.GetHandler().ExportToTJ(sheetsUrl, round);
+        }
+
+        [HumanOnly]
         [Command("exportToUCSD")]
         [Summary("Exports the scoresheet to the UCSD Scoresheet. Export requires that one or two teams are " +
             "playing, that each team has at most 6 players, and that at most 24 tossups have been played.")]
         [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings",
             Justification = "Discord.Net can't parse the argument directly as a URI")]
         public Task ExportToUCSDAsync(
-            [Summary("The URL to the UCSD Google Sheet. For example, https://docs.google.com/spreadsheets/d/00000-0oVdTQYtgzHPI7L8kf3xePu5fyi_u-00000000/edit#gid=12345678")] string sheetsUrl,
+            [Summary("The URL to the UCSD Google Sheet. For example, https://docs.google.com/spreadsheets/d/00000-0oVdTQYtgzHPI7L8kf3xePu5fyi_u-00000000")] string sheetsUrl,
             [Summary("The round number, starting from 1")][Remainder] int round)
         {
             return this.GetHandler().ExportToUCSD(sheetsUrl, round);

--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.6.0</Version>
+    <Version>3.7.0</Version>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Company />
     <Product>Quiz Bowl Discord Score Tracker</Product>

--- a/QuizBowlDiscordScoreTracker/Scoresheet/BaseGoogleSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/BaseGoogleSheetsGenerator.cs
@@ -1,0 +1,285 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Google.Apis.Sheets.v4.Data;
+using QuizBowlDiscordScoreTracker.TeamManager;
+
+namespace QuizBowlDiscordScoreTracker.Scoresheet
+{
+    public abstract class BaseGoogleSheetsGenerator : IGoogleSheetsGenerator
+    {
+        public BaseGoogleSheetsGenerator(IGoogleSheetsApi sheetsApi)
+        {
+            this.SheetsApi = sheetsApi;
+        }
+
+        // Used in tests
+        internal abstract int FirstPhaseRow { get; }
+
+        // TODO: This will likely disappear
+        internal abstract int LastBonusRow { get; }
+
+        internal abstract int PhasesLimit { get; }
+
+        // Used in tests
+        internal abstract int PlayersPerTeamLimit { get; }
+
+        // Used in tests
+        internal abstract ReadOnlyMemory<SpreadsheetColumn> StartingColumns { get; }
+
+        protected abstract List<string> ClearRostersRanges { get; }
+
+        protected abstract int PlayerNameRow { get; }
+
+        // Should this be SpreadsheetColumn?
+        protected abstract ReadOnlyMemory<SpreadsheetColumn> BonusColumns { get; }
+
+        protected abstract int TeamsLimit { get; }
+
+        protected abstract int TeamNameRow { get; }
+
+        private IGoogleSheetsApi SheetsApi { get; }
+
+        public async Task<IResult<string>> TryCreateScoresheet(GameState game, Uri sheetsUri, int roundNumber)
+        {
+            Verify.IsNotNull(game, nameof(game));
+            Verify.IsNotNull(sheetsUri, nameof(sheetsUri));
+
+            IReadOnlyDictionary<string, string> teamIdToNames = await game.TeamManager.GetTeamIdToNames();
+            if (teamIdToNames.Count == 0 || teamIdToNames.Count > 2)
+            {
+                return CreateFailureResult("Export only works if there are 1 or 2 teams in the game.");
+            }
+
+            // Make it an array so we don't keep re-evaluating the enumerable
+            PlayerTeamPair[] players = (await game.TeamManager.GetKnownPlayers()).ToArray();
+            IEnumerable<IGrouping<string, PlayerTeamPair>> playersByTeam = players.GroupBy(player => player.TeamId);
+            if (playersByTeam.Any(grouping => grouping.Count() > this.PlayersPerTeamLimit))
+            {
+                return CreateFailureResult("Export only currently works if there are at most 6 players on a team.");
+            }
+
+            string[] teamIds = playersByTeam.Select(grouping => grouping.Key).ToArray();
+
+            IEnumerable<PhaseScore> phaseScores = await game.GetPhaseScores();
+            int phaseScoresCount = phaseScores.Count();
+            if (phaseScoresCount > this.PhasesLimit + 1 ||
+                (phaseScoresCount == this.PhasesLimit + 1 && phaseScores.Last().ScoringSplitsOnActions.Any()))
+            {
+                return CreateFailureResult(
+                    $"Export only currently works if there are at most {this.PhasesLimit} tosusps answered in a game. Bonuses will only be tracked up to question { this.LastBonusRow - this.FirstPhaseRow + 1 }.");
+            }
+
+            IReadOnlyDictionary<ulong, SpreadsheetColumn> playerIdToColumn = this.CreatePlayerIdToColumnMapping(playersByTeam);
+            string sheetName = this.GetSheetName(roundNumber);
+            List<ValueRange> ranges = new List<ValueRange>
+            {
+                CreateUpdateSingleCellRequest(
+                    sheetName, this.StartingColumns.Span[0], this.TeamNameRow, teamIdToNames[playersByTeam.First().Key])
+            };
+
+            if (teamIdToNames.Count > 1 && playersByTeam.Skip(1).Any())
+            {
+                ranges.Add(CreateUpdateSingleCellRequest(
+                    sheetName, this.StartingColumns.Span[1], this.TeamNameRow, teamIdToNames[playersByTeam.ElementAt(1).Key]));
+            }
+
+            foreach (PlayerTeamPair pair in players)
+            {
+                // TODO: Make this more efficient by putting all the player names in one update request
+                SpreadsheetColumn column = playerIdToColumn[pair.PlayerId];
+                ranges.Add(CreateUpdateSingleCellRequest(sheetName, column, this.PlayerNameRow, pair.PlayerDisplayName));
+            }
+
+            // Tossup scoring should be similar, but some bonuses are 3 parts, while others are 1 value
+            // We can either let the sheets handle that, or do a switch here for 1 vs 3 part bonuses
+            // but we have the weird DT thing with TJSheets, so let's have abstract classes deal with it
+            int row = this.FirstPhaseRow;
+            int phasesCount = phaseScores.Count();
+            foreach (PhaseScore phaseScore in phaseScores)
+            {
+                foreach (ScoringSplitOnScoreAction action in phaseScore.ScoringSplitsOnActions)
+                {
+                    if (!playerIdToColumn.TryGetValue(action.Action.Buzz.UserId, out SpreadsheetColumn column))
+                    {
+                        return new FailureResult<string>(
+                            $"Unknown player {action.Action.Buzz.PlayerDisplayName} (ID {action.Action.Buzz.UserId}). Cannot accurately create a scoresheet. This happens in phase {row - this.FirstPhaseRow + 1}");
+                    }
+
+                    ranges.Add(CreateUpdateSingleCellRequest(sheetName, column, row, action.Action.Score));
+                }
+
+                IResult<IEnumerable<ValueRange>> additionalRanges = this.GetAdditionalUpdateRangesForTossup(
+                    phaseScore, teamIds, sheetName, row, phasesCount);
+                if (!additionalRanges.Success)
+                {
+                    return new FailureResult<string>(additionalRanges.ErrorMessage);
+                }
+
+                ranges.AddRange(additionalRanges.Value);
+
+                // We need to move this to the UpdateRanges method, since we may need to write other stuff
+                // Include that in the comment
+                if (row <= this.LastBonusRow)
+                {
+                    IResult<IEnumerable<ValueRange>> bonusRanges = this.GetUpdateRangesForBonus(
+                        phaseScore, teamIds, sheetName, row, phasesCount);
+                    if (!bonusRanges.Success)
+                    {
+                        return new FailureResult<string>(bonusRanges.ErrorMessage);
+                    }
+
+                    ranges.AddRange(bonusRanges.Value);
+                }
+
+                row++;
+            }
+
+            return await this.SheetsApi.UpdateGoogleSheet(ranges, this.GetClearRangesForBonus(sheetName), sheetsUri);
+        }
+
+        public async Task<IResult<string>> TryUpdateRosters(ITeamManager teamManager, Uri sheetsUri)
+        {
+            Verify.IsNotNull(teamManager, nameof(teamManager));
+            Verify.IsNotNull(sheetsUri, nameof(sheetsUri));
+
+            IReadOnlyDictionary<string, string> teamIdToNames = await teamManager.GetTeamIdToNames();
+
+            // Convert it to an array so we don't have to keep re-evaluating the GroupBy
+            IEnumerable<PlayerTeamPair> playerTeamPairs = await teamManager.GetKnownPlayers();
+            IGrouping<string, PlayerTeamPair>[] groupings = playerTeamPairs
+                .GroupBy(pair => pair.TeamId)
+                .Where(grouping => grouping.Any())
+                .ToArray();
+
+            if (groupings.Any(grouping => grouping.Count() > this.PlayersPerTeamLimit))
+            {
+                return CreateFailureResult(
+                    $"Rosters can only support up to {this.PlayersPerTeamLimit} players per team.");
+            }
+
+            if (groupings.Length > this.TeamsLimit)
+            {
+                return CreateFailureResult(
+                    $"Rosters can only support up to {this.TeamsLimit} teams.");
+            }
+
+            IResult<List<ValueRange>> rangesResult = this.GetUpdateRangesForRoster(teamIdToNames, groupings);
+            if (!rangesResult.Success)
+            {
+                return CreateFailureResult(rangesResult.ErrorMessage);
+            }
+
+            return await this.SheetsApi.UpdateGoogleSheet(rangesResult.Value, this.ClearRostersRanges, sheetsUri);
+        }
+
+        protected abstract List<string> GetClearRangesForBonus(string sheetName);
+
+        protected abstract string GetSheetName(int roundNumber);
+
+        protected abstract IResult<IEnumerable<ValueRange>> GetUpdateRangesForBonus(
+            PhaseScore phaseScore, string[] teamIds, string sheetName, int row, int phasesCount);
+
+        protected abstract IResult<IEnumerable<ValueRange>> GetAdditionalUpdateRangesForTossup(
+            PhaseScore phaseScore, string[] teamIds, string sheetName, int row, int phasesCount);
+
+        protected abstract IResult<List<ValueRange>> GetUpdateRangesForRoster(
+            IReadOnlyDictionary<string, string> teamIdToNames, IEnumerable<IGrouping<string, PlayerTeamPair>> groupings);
+
+        private IReadOnlyDictionary<ulong, SpreadsheetColumn> CreatePlayerIdToColumnMapping(
+            IEnumerable<IGrouping<string, PlayerTeamPair>> playersByTeam)
+        {
+            Dictionary<ulong, SpreadsheetColumn> playerIdToColumn = new Dictionary<ulong, SpreadsheetColumn>();
+            int startingColumnIndex = 0;
+            foreach (IGrouping<string, PlayerTeamPair> grouping in playersByTeam)
+            {
+                SpreadsheetColumn startingColumn = this.StartingColumns.Span[startingColumnIndex];
+                foreach (PlayerTeamPair pair in grouping)
+                {
+                    // TODO: If we ever support more than 6 players, we should bump up the next starting column
+                    playerIdToColumn[pair.PlayerId] = startingColumn;
+                    startingColumn = startingColumn + 1;
+                }
+
+                startingColumnIndex++;
+            }
+
+            return playerIdToColumn;
+        }
+
+        protected static FailureResult<string> CreateFailureResult(string errorMessage)
+        {
+            return new FailureResult<string>($"Couldn't write to the sheet. {errorMessage}");
+        }
+
+        protected static ValueRange CreateUpdateSingleCellRequest<T>(
+            string sheetName, SpreadsheetColumn column, int rowIndex, T value)
+        {
+            ValueRange range = new ValueRange()
+            {
+                Range = $"'{sheetName}'!{column}{rowIndex}",
+                Values = new List<IList<object>>()
+                {
+                    new List<object>()
+                    {
+                        value
+                    }
+                }
+            };
+
+            return range;
+        }
+
+        protected static ValueRange CreateUpdateCellsAlongColumnRequest<T>(
+            string sheetName, SpreadsheetColumn column, int rowNumber, IEnumerable<T> values)
+        {
+            Verify.IsNotNull(values, nameof(values));
+
+            // Subtract one, since the start column already covers the first value
+            int endRowIndex = rowNumber + (values.Count() - 1);
+            List<object> innerList = new List<object>();
+            foreach (T value in values)
+            {
+                innerList.Add(value);
+            }
+
+            ValueRange range = new ValueRange()
+            {
+                Range = $"'{sheetName}'!{column}{rowNumber}:{column}{endRowIndex}",
+                Values = new List<IList<object>>()
+                {
+                    innerList
+                },
+                MajorDimension = "COLUMNS"
+            };
+
+            return range;
+        }
+
+        protected static ValueRange CreateUpdateCellsAlongRowRequest<T>(
+            string sheetName, SpreadsheetColumn column, int rowNumber, IEnumerable<T> values)
+        {
+            Verify.IsNotNull(values, nameof(values));
+
+            // Subtract one, since the start column already covers the first value
+            SpreadsheetColumn endColumn = column + (values.Count() - 1);
+            List<object> innerList = new List<object>();
+            foreach (T value in values)
+            {
+                innerList.Add(value);
+            }
+
+            ValueRange range = new ValueRange()
+            {
+                Range = $"'{sheetName}'!{column}{rowNumber}:{endColumn}{rowNumber}",
+                Values = new List<IList<object>>()
+                {
+                    innerList
+                }
+            };
+
+            return range;
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Scoresheet/GoogleSheetsApi.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/GoogleSheetsApi.cs
@@ -44,7 +44,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
         }
 
         public Task<IResult<string>> UpdateGoogleSheet(
-            List<ValueRange> ranges, List<string> rangesToClear, Uri sheetsUri)
+            List<ValueRange> ranges, IList<string> rangesToClear, Uri sheetsUri)
         {
             Verify.IsNotNull(ranges, nameof(ranges));
             Verify.IsNotNull(rangesToClear, nameof(rangesToClear));
@@ -89,7 +89,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
         }
 
         private async Task<IResult<string>> UpdateGoogleSheet(
-            List<ValueRange> ranges, List<string> rangesToClear, Uri sheetsUri, int attemptedRetries)
+            List<ValueRange> ranges, IList<string> rangesToClear, Uri sheetsUri, int attemptedRetries)
         {
             if (this.Service == null)
             {

--- a/QuizBowlDiscordScoreTracker/Scoresheet/GoogleSheetsGeneratorFactory.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/GoogleSheetsGeneratorFactory.cs
@@ -16,6 +16,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
             return sheetsType switch
             {
                 GoogleSheetsType.UCSD => new UCSDGoogleSheetsGenerator(this.SheetsApi),
+                GoogleSheetsType.TJ => new TJSheetsGenerator(this.SheetsApi),
                 _ => throw new ArgumentException(
 $"Cannot create a generator for type {Enum.GetName(typeof(GoogleSheetsType), sheetsType)}"),
             };

--- a/QuizBowlDiscordScoreTracker/Scoresheet/GoogleSheetsType.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/GoogleSheetsType.cs
@@ -2,6 +2,7 @@
 {
     public enum GoogleSheetsType
     {
-        UCSD
+        UCSD,
+        TJ
     }
 }

--- a/QuizBowlDiscordScoreTracker/Scoresheet/IGoogleSheetsApi.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/IGoogleSheetsApi.cs
@@ -15,6 +15,6 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
         /// <param name="rangesToClear">The cells to clear</param>
         /// <param name="sheetsUri">The URI to the Google Sheets workbook/param>
         /// <returns></returns>
-        Task<IResult<string>> UpdateGoogleSheet(List<ValueRange> ranges, List<string> rangesToClear, Uri sheetsUri);
+        Task<IResult<string>> UpdateGoogleSheet(List<ValueRange> ranges, IList<string> rangesToClear, Uri sheetsUri);
     }
 }

--- a/QuizBowlDiscordScoreTracker/Scoresheet/IGoogleSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/IGoogleSheetsGenerator.cs
@@ -24,7 +24,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
         /// <param name="sheetsUri">URI to the Google Sheet with the worksheet for the tournament's rosters</param>
         /// <param name="sheetName">Name of the worksheet for the round we're creating a scoresheet for</param>
         /// <returns>A result with an error code if the update failed, or a result with an empty string on success</returns>
-        Task<IResult<string>> TryCreateScoresheet(GameState game, Uri sheetsUri, string sheetName);
+        Task<IResult<string>> TryCreateScoresheet(GameState game, Uri sheetsUri, int roundNumber);
 
         /// <summary>
         /// Updates the rosters spreadsheet in the Google Sheet

--- a/QuizBowlDiscordScoreTracker/Scoresheet/SpreadsheetColumn.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/SpreadsheetColumn.cs
@@ -1,0 +1,100 @@
+﻿using System;
+
+namespace QuizBowlDiscordScoreTracker.Scoresheet
+{
+    // We could represent it generally (from A-ZZZZ...), but we only really need two digits, and it simplifies the code
+    /// <summary>
+    /// This can represent cells from A-ZZ
+    /// </summary>
+    public class SpreadsheetColumn
+    {
+        public const char StartingColumn = 'A';
+        public const int MaximumColumnNumber = 26 * 26 + 26;
+
+        /// <summary>
+        /// Represents a column from A to ZZ. The column number starts from 1 and goes up to MaximumColumnNumber.
+        /// </summary>
+        /// <param name="columnNumber">The number of the column. 1 is the lowest column number.</param>
+        public SpreadsheetColumn(int columnNumber)
+        {
+            if (columnNumber < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(columnNumber), $"{nameof(columnNumber)} must be >= 1");
+            }
+            else if (columnNumber > MaximumColumnNumber)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(columnNumber), $"{nameof(columnNumber)} must be <= {MaximumColumnNumber}");
+            }
+
+            this.ColumnIndex = columnNumber - 1;
+        }
+
+        public SpreadsheetColumn(char column) : this((int)(column - 'A') + 1)
+        {
+        }
+
+        private int ColumnIndex { get; set; }
+
+        public static SpreadsheetColumn operator +(SpreadsheetColumn column, int value)
+        {
+            Verify.IsNotNull(column, nameof(column));
+
+            // SpreadsheetColumn expects a number, so account for it in the result by adding 1 to each index
+            int result = checked(column.ColumnIndex + 1 + value);
+            return new SpreadsheetColumn(result);
+        }
+
+        public static SpreadsheetColumn operator -(SpreadsheetColumn column, int value)
+        {
+            Verify.IsNotNull(column, nameof(column));
+
+            // The correction from index to number should cancel out
+            int result = checked(column.ColumnIndex + 1 - value);
+            return new SpreadsheetColumn(result);
+        }
+
+        public static SpreadsheetColumn Add(SpreadsheetColumn left, int right)
+        {
+            return left + right;
+        }
+
+        public static SpreadsheetColumn Subtract(SpreadsheetColumn left, int right)
+        {
+            return left - right;
+        }
+
+        public override string ToString()
+        {
+            // Handle the case where column < 26, and where column < 26 * 26
+            // Probably easiest through an if statement
+            // < 26 => (char)(65 + column) or 'A' + column
+            // >= 26 -> ('A' + (column / 26))('A' + (column % 26)))
+            if (this.ColumnIndex < 26)
+            {
+                char column = (char)(StartingColumn + this.ColumnIndex);
+                return column.ToString();
+            }
+
+            // We know ColumnIndex >= 26, so this.ColumnIndex / 26 >= 1. We want to start off in the starting column,
+            // so subtract 1 from the division so we start at A.
+            int leadingDigitOffset = this.ColumnIndex / 26 - 1;
+            return $"{(char)(StartingColumn + leadingDigitOffset)}{(char)(StartingColumn + (this.ColumnIndex % 26))}";
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is SpreadsheetColumn column))
+            {
+                return false;
+            }
+
+            return this.ColumnIndex == column.ColumnIndex;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.ColumnIndex;
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Scoresheet/TJSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/TJSheetsGenerator.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Google.Apis.Sheets.v4.Data;
+
+namespace QuizBowlDiscordScoreTracker.Scoresheet
+{
+    public class TJSheetsGenerator : BaseGoogleSheetsGenerator
+    {
+        internal const int RostersFirstPlayerRow = 2;
+
+        internal const string RostersSheetName = "ROSTERS";
+        internal static readonly ReadOnlyMemory<SpreadsheetColumn> StartingColumnsArray = new SpreadsheetColumn[]
+        {
+            new SpreadsheetColumn('C'),
+            new SpreadsheetColumn('M')
+        };
+        internal static readonly ReadOnlyMemory<SpreadsheetColumn> BonusColumnsArray = new SpreadsheetColumn[]
+        {
+            new SpreadsheetColumn('I'),
+            new SpreadsheetColumn('S')
+        };
+
+        private static readonly List<string> ClearRosters = new List<string>() { $"'{RostersSheetName}'!A1:ZZ21" };
+        private static readonly SpreadsheetColumn RostersFirstTeamColumn = new SpreadsheetColumn(1);
+
+        public TJSheetsGenerator(IGoogleSheetsApi sheetsApi) : base(sheetsApi)
+        {
+        }
+
+        internal override int FirstPhaseRow => 4;
+
+        internal override int LastBonusRow => 23;
+
+        internal override int PhasesLimit => 24;
+
+        // TJ Sheets doesn't really have a roster player limit, but we use 6 because the scoresheet limits it to 6,
+        // and it greatly simplifies the logic
+        internal override int PlayersPerTeamLimit => 6;
+
+        internal override ReadOnlyMemory<SpreadsheetColumn> StartingColumns => StartingColumnsArray;
+
+        protected override List<string> ClearRostersRanges => ClearRosters;
+
+        protected override int PlayerNameRow => 3;
+
+        protected override ReadOnlyMemory<SpreadsheetColumn> BonusColumns => BonusColumnsArray;
+
+        protected override int TeamsLimit => 2000;
+
+        protected override int TeamNameRow => 2;
+
+        protected override IResult<IEnumerable<ValueRange>> GetAdditionalUpdateRangesForTossup(
+            PhaseScore phaseScore, string[] teamIds, string sheetName, int row, int phasesCount)
+        {
+            Verify.IsNotNull(phaseScore, nameof(phaseScore));
+
+            if (row == this.FirstPhaseRow + phasesCount - 1 && !phaseScore.ScoringSplitsOnActions.Any())
+            {
+                // We're in the last phase, and nothing has happened, so it's a placeholder phase for any future
+                // scoring actions. This shouldn't be put into the scoresheet.
+                return new SuccessResult<IEnumerable<ValueRange>>(Enumerable.Empty<ValueRange>());
+            }
+
+            // If the question went dead, put in "DT" in the first bonus column to indicate that the question was read
+            if (phaseScore.ScoringSplitsOnActions.All(split => split.Action.Score <= 0))
+            {
+                List<ValueRange> ranges = new List<ValueRange>();
+                ranges.Add(CreateUpdateSingleCellRequest(sheetName, this.BonusColumns.Span[0], row, "DT"));
+                return new SuccessResult<IEnumerable<ValueRange>>(ranges);
+            }
+
+            return new SuccessResult<IEnumerable<ValueRange>>(Enumerable.Empty<ValueRange>());
+        }
+
+        protected override string GetSheetName(int roundNumber)
+        {
+            return $"ROUND {roundNumber}";
+        }
+
+        protected override List<string> GetClearRangesForBonus(string sheetName)
+        {
+            // We want to include all the player columns, and the bonus column, so don't include - 1
+            int columnsAfterInitial = this.PlayersPerTeamLimit;
+            return new List<string>()
+            {
+                // Add 5 to the column because the sheet supports 6 players. The first column counts as the first
+                // player already.
+                $"'{sheetName}'!{StartingColumnsArray.Span[0]}4:{StartingColumnsArray.Span[0] + columnsAfterInitial}27",
+                $"'{sheetName}'!{StartingColumnsArray.Span[1]}4:{StartingColumnsArray.Span[1] + columnsAfterInitial}27",
+            };
+        }
+
+        protected override IResult<IEnumerable<ValueRange>> GetUpdateRangesForBonus(
+            PhaseScore phaseScore, string[] teamIds, string sheetName, int row, int phasesCount)
+        {
+            Verify.IsNotNull(phaseScore, nameof(phaseScore));
+
+            List<ValueRange> ranges = new List<ValueRange>();
+            if (phaseScore.BonusScores?.Any() == true)
+            {
+                int bonusScoresIndex = Array.IndexOf(teamIds, phaseScore.BonusTeamId);
+                if (bonusScoresIndex < 0)
+                {
+                    return new FailureResult<IEnumerable<ValueRange>>(
+                        $"Unknown bonus team in phase {row - this.FirstPhaseRow + 1}. Cannot accurately create a scoresheet.");
+                }
+
+                int bonusTotal = phaseScore.BonusScores.Sum();
+                if (bonusTotal != 0 && bonusTotal != 10 && bonusTotal != 20 && bonusTotal != 30)
+                {
+                    return new FailureResult<IEnumerable<ValueRange>>(
+                        $"Invalid bonus value in phase {row - this.FirstPhaseRow + 1}. Value must be 0/10/20/30, but it was {bonusTotal}");
+                }
+
+                SpreadsheetColumn bonusColumn = this.BonusColumns.Span[bonusScoresIndex];
+                ranges.Add(CreateUpdateSingleCellRequest(sheetName, bonusColumn, row, bonusTotal));
+            }
+            else if (row != this.FirstPhaseRow + phasesCount - 1 || phaseScore.ScoringSplitsOnActions.Any())
+            {
+                // We need to find if anyone got it correct, and if so, what team they are on. Fill that bonus
+                // column with 0.
+                ScoringSplitOnScoreAction split = phaseScore.ScoringSplitsOnActions
+                    .FirstOrDefault(split => split.Action.Score > 0);
+                if (split != null)
+                {
+                    int bonusIndex = Array.IndexOf(teamIds, split.Action.Buzz.TeamId);
+                    if (bonusIndex < 0 || bonusIndex >= 2)
+                    {
+                        return new FailureResult<IEnumerable<ValueRange>>(
+                            $"Unknown bonus team in phase {row - this.FirstPhaseRow + 1}. Cannot accurately create a scoresheet.");
+                    }
+
+                    ranges.Add(CreateUpdateSingleCellRequest(sheetName, this.BonusColumns.Span[bonusIndex], row, 0));
+                }
+            }
+
+            return new SuccessResult<IEnumerable<ValueRange>>(ranges);
+        }
+
+        protected override IResult<List<ValueRange>> GetUpdateRangesForRoster(
+            IReadOnlyDictionary<string, string> teamIdToNames, IEnumerable<IGrouping<string, PlayerTeamPair>> groupings)
+        {
+            Verify.IsNotNull(groupings, nameof(groupings));
+
+            // Need to put teams in first row
+            List<ValueRange> ranges = new List<ValueRange>();
+            IEnumerable<string> teamNames = groupings
+                .Select(grouping => teamIdToNames.TryGetValue(grouping.Key, out string name) ?
+                    name :
+                    grouping.First().PlayerDisplayName);
+            ranges.Add(CreateUpdateCellsAlongRowRequest(RostersSheetName, RostersFirstTeamColumn, 1, teamNames));
+
+            SpreadsheetColumn teamColumn = RostersFirstTeamColumn;
+            foreach (IGrouping<string, PlayerTeamPair> grouping in groupings)
+            {
+                IEnumerable<string> playerNames = grouping.Select(pair => pair.PlayerDisplayName);
+                ranges.Add(CreateUpdateCellsAlongColumnRequest(
+                    RostersSheetName, teamColumn, RostersFirstPlayerRow, playerNames));
+
+                teamColumn = teamColumn + 1;
+            }
+
+            return new SuccessResult<List<ValueRange>>(ranges);
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTracker/Scoresheet/UCSDGoogleSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/UCSDGoogleSheetsGenerator.cs
@@ -1,183 +1,66 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Google.Apis.Sheets.v4.Data;
-using QuizBowlDiscordScoreTracker.TeamManager;
 
 namespace QuizBowlDiscordScoreTracker.Scoresheet
 {
     // TODO: Eventually allow for more columns than Z (can even just do up to ZZ: +500 unrealistic for QB)
     // TODO: Add reader name to mod/scorekeeper section
 
-    public sealed class UCSDGoogleSheetsGenerator : IGoogleSheetsGenerator
+    public sealed class UCSDGoogleSheetsGenerator : BaseGoogleSheetsGenerator
     {
-        internal const int FirstPhaseRow = 4;
-        internal const int PlayersPerTeamLimit = 6;
-        internal const int PhasesLimit = 28;
-        internal const int LastBonusRow = 27;
         internal const string RostersSheetName = "Rosters";
-        internal static readonly ReadOnlyMemory<char> StartingColumnsChars = new char[] { 'C', 'O' };
+        internal static readonly ReadOnlyMemory<SpreadsheetColumn> StartingColumnsArray = new SpreadsheetColumn[]
+        {
+            new SpreadsheetColumn('C'),
+            new SpreadsheetColumn('O')
+        };
 
-        private const int TeamNameRow = 1;
-        private const int PlayerNameRow = 3;
-
-        private static readonly char[] BonusColumns = new char[] { 'I', 'U' };
+        private static readonly SpreadsheetColumn[] BonusColumnsArray = new SpreadsheetColumn[]
+        {
+            new SpreadsheetColumn('I'),
+            new SpreadsheetColumn('U')
+        };
         private static readonly bool[] ClearedBonusArray = new bool[] { false, false, false };
+        private static readonly SpreadsheetColumn FirstColumn = new SpreadsheetColumn(1);
 
         private static readonly List<string> ClearRosters = new List<string>() { $"'{RostersSheetName}'!A2:G999" };
 
-        public UCSDGoogleSheetsGenerator(IGoogleSheetsApi sheetsApi)
+        public UCSDGoogleSheetsGenerator(IGoogleSheetsApi sheetsApi) : base(sheetsApi)
         {
-            this.SheetsApi = sheetsApi;
         }
 
-        private IGoogleSheetsApi SheetsApi { get; }
+        protected override List<string> ClearRostersRanges => ClearRosters;
 
-        public async Task<IResult<string>> TryCreateScoresheet(GameState game, Uri sheetsUri, string sheetName)
+        internal override int FirstPhaseRow => 4;
+
+        internal override int LastBonusRow => 27;
+
+        internal override int PhasesLimit => 28;
+
+        protected override int PlayerNameRow => 3;
+
+        internal override int PlayersPerTeamLimit => 6;
+
+        internal override ReadOnlyMemory<SpreadsheetColumn> StartingColumns => StartingColumnsArray;
+
+        protected override ReadOnlyMemory<SpreadsheetColumn> BonusColumns => BonusColumnsArray;
+
+        protected override int TeamsLimit => 100;
+
+        protected override int TeamNameRow => 1;
+
+        protected override IResult<IEnumerable<ValueRange>> GetAdditionalUpdateRangesForTossup(
+            PhaseScore phaseScore, string[] teamIds, string sheetName, int row, int phasesCount)
         {
-            Verify.IsNotNull(game, nameof(game));
-            Verify.IsNotNull(sheetsUri, nameof(sheetsUri));
-
-            // TODO: Initializing the team and player mappings is the same as ExcleFileScoresheetGenerator. See if we
-            // can unify this, if the abstractions make sense.
-            IReadOnlyDictionary<string, string> teamIdToNames = await game.TeamManager.GetTeamIdToNames();
-            if (teamIdToNames.Count == 0 || teamIdToNames.Count > 2)
-            {
-                return CreateFailureResult("Export only works if there are 1 or 2 teams in the game.");
-            }
-
-            // Make it an array so we don't keep re-evaluating the enumerable
-            PlayerTeamPair[] players = (await game.TeamManager.GetKnownPlayers()).ToArray();
-            IEnumerable<IGrouping<string, PlayerTeamPair>> playersByTeam = players.GroupBy(player => player.TeamId);
-            if (playersByTeam.Any(grouping => grouping.Count() > PlayersPerTeamLimit))
-            {
-                return CreateFailureResult("Export only currently works if there are at most 6 players on a team.");
-            }
-
-            string[] teamIds = playersByTeam.Select(grouping => grouping.Key).ToArray();
-
-            // We could have an extra phase, but if there are no scoring actions, then it wasn't played
-            IEnumerable<PhaseScore> phaseScores = await game.GetPhaseScores();
-            int phaseScoresCount = phaseScores.Count();
-            if (phaseScoresCount > PhasesLimit + 1 ||
-                (phaseScoresCount == PhasesLimit + 1 && phaseScores.Last().ScoringSplitsOnActions.Any()))
-            {
-                return CreateFailureResult(
-                    $"Export only currently works if there are at most {PhasesLimit} tosusps answered in a game. Bonuses will only be tracked up to question 24.");
-            }
-
-            // TODO: When Formats are supported (so bonuses stop after a certain number of questions), support the
-            // tiebreakers.
-
-            IReadOnlyDictionary<ulong, char> playerIdToColumn = CreatePlayerIdToColumnMapping(playersByTeam);
-
-            // TODO: See if filling in player's scores by columns can be done efficiently, since it should require less
-            // requests
-            List<ValueRange> ranges = new List<ValueRange>
-            {
-                CreateUpdateSingleCellRequest(
-                    sheetName, StartingColumnsChars.Span[0], TeamNameRow, teamIdToNames[playersByTeam.First().Key])
-            };
-            if (teamIdToNames.Count > 1)
-            {
-                ranges.Add(CreateUpdateSingleCellRequest(
-                    sheetName, StartingColumnsChars.Span[1], TeamNameRow, teamIdToNames[playersByTeam.ElementAt(1).Key]));
-            }
-
-            foreach (PlayerTeamPair pair in players)
-            {
-                // TODO: Make this more efficient by putting all the player names in one update request
-                char column = playerIdToColumn[pair.PlayerId];
-                ranges.Add(CreateUpdateSingleCellRequest(sheetName, column, PlayerNameRow, pair.PlayerDisplayName));
-            }
-
-            int row = FirstPhaseRow;
-            List<char> scoredColumns = new List<char>();
-            foreach (PhaseScore phaseScore in phaseScores)
-            {
-                foreach (ScoringSplitOnScoreAction action in phaseScore.ScoringSplitsOnActions)
-                {
-                    if (!playerIdToColumn.TryGetValue(action.Action.Buzz.UserId, out char column))
-                    {
-                        return new FailureResult<string>(
-                            $"Unknown player {action.Action.Buzz.PlayerDisplayName} (ID {action.Action.Buzz.UserId}). Cannot accurately create a scoresheet. This happens in phase {row - FirstPhaseRow + 1}");
-                    }
-
-                    ranges.Add(CreateUpdateSingleCellRequest(sheetName, column, row, action.Action.Score));
-                    scoredColumns.Add(column);
-                }
-
-                scoredColumns.Clear();
-
-                if (row <= LastBonusRow)
-                {
-                    if (phaseScore.BonusScores?.Any() == true)
-                    {
-                        int bonusPartCount = phaseScore.BonusScores.Count();
-                        if (bonusPartCount != 3)
-                        {
-                            return new FailureResult<string>(
-                                $"Non-three part bonus in phase {row - FirstPhaseRow + 1}. Number of parts: {bonusPartCount}. These aren't supported for the scoresheet.");
-                        }
-
-                        int bonusScoresIndex = Array.IndexOf(teamIds, phaseScore.BonusTeamId);
-                        if (bonusScoresIndex < 0)
-                        {
-                            return new FailureResult<string>(
-                                $"Unknown bonus team in phase {row - FirstPhaseRow + 1}. Cannot accurately create a scoresheet.");
-                        }
-
-                        char bonusColumn = BonusColumns[bonusScoresIndex];
-                        ranges.Add(CreateUpdateCellsAlongRowRequest(
-                            sheetName, bonusColumn, row, phaseScore.BonusScores.Select(score => score > 0).ToArray()));
-
-                        char otherBonusColumn = BonusColumns[BonusColumns.Length - bonusScoresIndex - 1];
-                        ranges.Add(CreateUpdateCellsAlongRowRequest(
-                            sheetName, otherBonusColumn, row, ClearedBonusArray));
-                    }
-                    else
-                    {
-                        // Clear the bonus columns
-                        foreach (char column in BonusColumns)
-                        {
-                            ranges.Add(CreateUpdateCellsAlongRowRequest(sheetName, column, row, ClearedBonusArray));
-                        }
-                    }
-                }
-
-                row++;
-            }
-
-            int columnsAfterInitial = PlayersPerTeamLimit - 1;
-            List<string> rangesToClear = new List<string>()
-            {
-                // Add 5 to the column because the sheet supports 6 players. The first column counts as the first
-                // player already.
-                $"'{sheetName}'!{StartingColumnsChars.Span[0]}4:{(char)(StartingColumnsChars.Span[0] + columnsAfterInitial)}31",
-                $"'{sheetName}'!{StartingColumnsChars.Span[1]}4:{(char)(StartingColumnsChars.Span[1] + columnsAfterInitial)}31",
-            };
-
-            return await this.SheetsApi.UpdateGoogleSheet(ranges, rangesToClear, sheetsUri);
+            return new SuccessResult<IEnumerable<ValueRange>>(Enumerable.Empty<ValueRange>());
         }
 
-        public async Task<IResult<string>> TryUpdateRosters(ITeamManager teamManager, Uri sheetsUri)
+        protected override IResult<List<ValueRange>> GetUpdateRangesForRoster(
+            IReadOnlyDictionary<string, string> teamIdToNames,
+            IEnumerable<IGrouping<string, PlayerTeamPair>> groupings)
         {
-            Verify.IsNotNull(teamManager, nameof(teamManager));
-            Verify.IsNotNull(sheetsUri, nameof(sheetsUri));
-
-            IReadOnlyDictionary<string, string> teamIdToNames = await teamManager.GetTeamIdToNames();
-
-            IEnumerable<PlayerTeamPair> playerTeamPairs = await teamManager.GetKnownPlayers();
-            IEnumerable<IGrouping<string, PlayerTeamPair>> groupings = playerTeamPairs
-                .GroupBy(pair => pair.TeamId)
-                .Where(grouping => grouping.Any());
-
-            if (groupings.Any(grouping => grouping.Count() > PlayersPerTeamLimit))
-            {
-                return CreateFailureResult("Rosters can only support up to 6 players per team.");
-            }
-
             int row = 2;
             List<ValueRange> ranges = new List<ValueRange>();
             foreach (IGrouping<string, PlayerTeamPair> grouping in groupings)
@@ -192,81 +75,72 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
                 IEnumerable<string> playerNames = grouping.Select(pair => pair.PlayerDisplayName);
                 IEnumerable<string> rowValues = new string[] { teamName }
                     .Concat(playerNames);
-                ranges.Add(CreateUpdateCellsAlongRowRequest(RostersSheetName, 'A', row, rowValues));
+                ranges.Add(CreateUpdateCellsAlongRowRequest(RostersSheetName, FirstColumn, row, rowValues));
 
                 row++;
             }
 
-            // Go through the teams and update rosters
-            return await this.SheetsApi.UpdateGoogleSheet(ranges, ClearRosters, sheetsUri);
+            return new SuccessResult<List<ValueRange>>(ranges);
         }
 
-        private static FailureResult<string> CreateFailureResult(string errorMessage)
+        protected override string GetSheetName(int roundNumber)
         {
-            return new FailureResult<string>($"Couldn't write to the sheet. {errorMessage}");
+            return $"Round {roundNumber}";
         }
 
-        // This is similar to the one in ExcelFileScoresheetGenerator, but it works on
-        private static IReadOnlyDictionary<ulong, char> CreatePlayerIdToColumnMapping(
-            IEnumerable<IGrouping<string, PlayerTeamPair>> playersByTeam)
+        protected override IResult<IEnumerable<ValueRange>> GetUpdateRangesForBonus(
+            PhaseScore phaseScore, string[] teamIds, string sheetName, int row, int phasesCount)
         {
-            Dictionary<ulong, char> playerIdToColumn = new Dictionary<ulong, char>();
-            int startingColumnIndex = 0;
-            foreach (IGrouping<string, PlayerTeamPair> grouping in playersByTeam)
+            Verify.IsNotNull(phaseScore, nameof(phaseScore));
+
+            List<ValueRange> ranges = new List<ValueRange>();
+            if (phaseScore.BonusScores?.Any() == true)
             {
-                char startingColumn = StartingColumnsChars.Span[startingColumnIndex];
-                foreach (PlayerTeamPair pair in grouping)
+                int bonusPartCount = phaseScore.BonusScores.Count();
+                if (bonusPartCount != 3)
                 {
-                    // TODO: If we ever support more than 6 players, we should bump up the next starting column
-                    playerIdToColumn[pair.PlayerId] = startingColumn++;
+                    return new FailureResult<IEnumerable<ValueRange>>(
+                        $"Non-three part bonus in phase {row - this.FirstPhaseRow + 1}. Number of parts: {bonusPartCount}. These aren't supported for the scoresheet.");
                 }
 
-                startingColumnIndex++;
+                int bonusScoresIndex = Array.IndexOf(teamIds, phaseScore.BonusTeamId);
+                if (bonusScoresIndex < 0)
+                {
+                    return new FailureResult<IEnumerable<ValueRange>>(
+                        $"Unknown bonus team in phase {row - this.FirstPhaseRow + 1}. Cannot accurately create a scoresheet.");
+                }
+
+                SpreadsheetColumn bonusColumn = this.BonusColumns.Span[bonusScoresIndex];
+                ranges.Add(CreateUpdateCellsAlongRowRequest(
+                    sheetName, bonusColumn, row, phaseScore.BonusScores.Select(score => score > 0).ToArray()));
+
+                SpreadsheetColumn otherBonusColumn = this.BonusColumns.Span[this.BonusColumns.Length - bonusScoresIndex - 1];
+                ranges.Add(CreateUpdateCellsAlongRowRequest(
+                    sheetName, otherBonusColumn, row, ClearedBonusArray));
+            }
+            else
+            {
+                // Clear the bonus columns
+                for (int i = 0; i < this.BonusColumns.Span.Length; i++)
+                {
+                    ranges.Add(CreateUpdateCellsAlongRowRequest(
+                        sheetName, this.BonusColumns.Span[i], row, ClearedBonusArray));
+                }
             }
 
-            return playerIdToColumn;
+            return new SuccessResult<IEnumerable<ValueRange>>(ranges);
         }
 
-        // TODO: If the sheet ever supports columns past Z, we need to use a string or wrapper class for AA and above
-        private static ValueRange CreateUpdateSingleCellRequest<T>(string sheetName, char column, int rowIndex, T value)
+        protected override List<string> GetClearRangesForBonus(string sheetName)
         {
-            ValueRange range = new ValueRange()
+            int columnsAfterInitial = this.PlayersPerTeamLimit - 1;
+            return new List<string>()
             {
-                Range = $"'{sheetName}'!{column}{rowIndex}",
-                Values = new List<IList<object>>()
-                {
-                    new List<object>()
-                    {
-                        value
-                    }
-                }
+                // Add 5 to the column because the sheet supports 6 players. The first column counts as the first
+                // player already.
+                $"'{sheetName}'!{this.StartingColumns.Span[0]}4:{this.StartingColumns.Span[0] + columnsAfterInitial}31",
+                $"'{sheetName}'!{this.StartingColumns.Span[1]}4:{this.StartingColumns.Span[1] + columnsAfterInitial}31",
             };
-
-            return range;
-        }
-
-        // TODO: If the sheet ever supports columns past Z, we need to use a string or wrapper class for AA and above
-        private static ValueRange CreateUpdateCellsAlongRowRequest<T>(
-            string sheetName, char column, int rowIndex, IEnumerable<T> values)
-        {
-            // Subtract one, since the start column already covers the first value
-            char endColumn = (char)(column + values.Count() - 1);
-            List<object> innerList = new List<object>();
-            foreach (T value in values)
-            {
-                innerList.Add(value);
-            }
-
-            ValueRange range = new ValueRange()
-            {
-                Range = $"'{sheetName}'!{column}{rowIndex}:{endColumn}{rowIndex}",
-                Values = new List<IList<object>>()
-                {
-                    innerList
-                }
-            };
-
-            return range;
         }
     }
 }

--- a/QuizBowlDiscordScoreTracker/TeamManager/ByRoleTeamManager.cs
+++ b/QuizBowlDiscordScoreTracker/TeamManager/ByRoleTeamManager.cs
@@ -62,10 +62,11 @@ namespace QuizBowlDiscordScoreTracker.TeamManager
             IReadOnlyDictionary<string, string> teamIdToName = (IReadOnlyDictionary<string, string>)this.TeamIdToName;
             return Task.FromResult(teamIdToName);
         }
-        public void ReloadTeamRoles(out string message)
+
+        public string ReloadTeamRoles()
         {
             this.InitiailzeTeamIdToName();
-            message = $@"Team roles reloaded. There are now {this.TeamIdToName.Count} team(s)";
+            return $@"Team roles reloaded. There are now {this.TeamIdToName.Count} team(s)";
         }
 
         private void InitiailzeTeamIdToName()

--- a/QuizBowlDiscordScoreTracker/TeamManager/IByRoleTeamManager.cs
+++ b/QuizBowlDiscordScoreTracker/TeamManager/IByRoleTeamManager.cs
@@ -7,6 +7,10 @@ namespace QuizBowlDiscordScoreTracker.TeamManager
 {
     public interface IByRoleTeamManager
     {
-        void ReloadTeamRoles(out string message);
+        /// <summary>
+        /// Reloads teams from the roles
+        /// </summary>
+        /// <returns>Returns the message to report after the roles were reloaded</returns>
+        string ReloadTeamRoles();
     }
 }

--- a/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
@@ -356,7 +356,63 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
+        public async Task SetRostersFromRolesForTJSheetsFails()
+        {
+            await this.SetRostersFromRolesForGoogleSheetsFails(
+                GoogleSheetsType.TJ, (url) => this.Handler.SetRostersFromRolesForTJ(url));
+        }
+
+        [TestMethod]
+        public async Task SetRostersFromRolesForTJSheetsSucceeds()
+        {
+            await this.SetRostersFromRolesForGoogleSheetsSucceeds(
+                GoogleSheetsType.TJ, (url) => this.Handler.SetRostersFromRolesForTJ(url));
+        }
+
+        [TestMethod]
+        public async Task SetRostersFromRolesForTJSheetsWithoutByRoleTeamsFails()
+        {
+            await this.SetRostersFromRolesForGoogleSheetsWithoutByRoleTeamsFails(
+                GoogleSheetsType.TJ, (url) => this.Handler.SetRostersFromRolesForTJ(url));
+        }
+
+        [TestMethod]
+        public async Task SetRostersFromRolesForTJSheetsWithBadUrlFails()
+        {
+            await this.SetRostersFromRolesForGoogleSheetsWithBadUrlFails(
+                GoogleSheetsType.TJ, (url) => this.Handler.SetRostersFromRolesForTJ(url));
+        }
+
+        [TestMethod]
         public async Task SetRostersFromRolesForUCSDFails()
+        {
+            await this.SetRostersFromRolesForGoogleSheetsFails(
+                GoogleSheetsType.UCSD, (url) => this.Handler.SetRostersFromRolesForUCSD(url));
+        }
+
+        [TestMethod]
+        public async Task SetRostersFromRolesForUCSDSucceeds()
+        {
+            await this.SetRostersFromRolesForGoogleSheetsSucceeds(
+                GoogleSheetsType.UCSD, (url) => this.Handler.SetRostersFromRolesForUCSD(url));
+        }
+
+        [TestMethod]
+        public async Task SetRostersFromRolesForUCSDWithoutByRoleTeamsFails()
+        {
+            await this.SetRostersFromRolesForGoogleSheetsWithoutByRoleTeamsFails(
+                GoogleSheetsType.UCSD, (url) => this.Handler.SetRostersFromRolesForUCSD(url));
+        }
+
+        [TestMethod]
+        public async Task SetRostersFromRolesForUCSDWithBadUrlFails()
+        {
+            await this.SetRostersFromRolesForGoogleSheetsWithBadUrlFails(
+                GoogleSheetsType.UCSD, (url) => this.Handler.SetRostersFromRolesForUCSD(url));
+        }
+
+        private async Task SetRostersFromRolesForGoogleSheetsFails(
+            GoogleSheetsType type, Func<string, Task> setRosters)
         {
             const string errorMessage = "API call failed";
 
@@ -368,7 +424,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             Mock<IGoogleSheetsGeneratorFactory> mockFactory = new Mock<IGoogleSheetsGeneratorFactory>();
             mockFactory
-                .Setup(factory => factory.Create(GoogleSheetsType.UCSD))
+                .Setup(factory => factory.Create(type))
                 .Returns(mockGenerator.Object);
 
             this.InitializeHandler(googleSheetsGeneratorFactory: mockFactory.Object);
@@ -379,14 +435,14 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 await action.SetTeamRolePrefixAsync(DefaultGuildId, TeamRolePrefix);
             }
 
-            await this.Handler.SetRostersFromRolesForUCSD("http://localhost/sheetsUrl");
+            await setRosters("http://localhost/sheetsUrl");
 
             mockFactory.Verify();
             this.MessageStore.VerifyChannelMessages(errorMessage);
         }
 
-        [TestMethod]
-        public async Task SetRostersFromRolesForUCSDSucceeds()
+        private async Task SetRostersFromRolesForGoogleSheetsSucceeds(
+            GoogleSheetsType type, Func<string, Task> setRosters)
         {
             Mock<IGoogleSheetsGenerator> mockGenerator = new Mock<IGoogleSheetsGenerator>();
             mockGenerator
@@ -396,7 +452,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             Mock<IGoogleSheetsGeneratorFactory> mockFactory = new Mock<IGoogleSheetsGeneratorFactory>();
             mockFactory
-                .Setup(factory => factory.Create(GoogleSheetsType.UCSD))
+                .Setup(factory => factory.Create(type))
                 .Returns(mockGenerator.Object);
 
             this.InitializeHandler(googleSheetsGeneratorFactory: mockFactory.Object);
@@ -407,14 +463,14 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 await action.SetTeamRolePrefixAsync(DefaultGuildId, TeamRolePrefix);
             }
 
-            await this.Handler.SetRostersFromRolesForUCSD("http://localhost/sheetsUrl");
+            await setRosters("http://localhost/sheetsUrl");
 
             mockFactory.Verify();
             this.MessageStore.VerifyChannelMessages("Rosters updated.");
         }
 
-        [TestMethod]
-        public async Task SetRostersFromRolesForUCSDWithoutByRoleTeamsFails()
+        private async Task SetRostersFromRolesForGoogleSheetsWithoutByRoleTeamsFails(
+            GoogleSheetsType type, Func<string, Task> setRosters)
         {
             Mock<IGoogleSheetsGenerator> mockGenerator = new Mock<IGoogleSheetsGenerator>();
             mockGenerator
@@ -424,20 +480,20 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             Mock<IGoogleSheetsGeneratorFactory> mockFactory = new Mock<IGoogleSheetsGeneratorFactory>();
             mockFactory
-                .Setup(factory => factory.Create(GoogleSheetsType.UCSD))
+                .Setup(factory => factory.Create(type))
                 .Returns(mockGenerator.Object);
 
             this.InitializeHandler(googleSheetsGeneratorFactory: mockFactory.Object);
 
-            await this.Handler.SetRostersFromRolesForUCSD("http://localhost/sheetsUrl");
+            await setRosters("http://localhost/sheetsUrl");
 
             this.MessageStore.VerifyChannelMessages(
                 "Couldn't export to the rosters sheet. This server is not using the team role prefix. Use !setTeamRolePrefix to set the prefix for role names to use for teams.");
             mockFactory.Verify(factory => factory.Create(It.IsAny<GoogleSheetsType>()), Times.Never);
         }
 
-        [TestMethod]
-        public async Task SetRostersFromRolesForUCSDWithBadUrlFails()
+        private async Task SetRostersFromRolesForGoogleSheetsWithBadUrlFails(
+            GoogleSheetsType type, Func<string, Task> setRosters)
         {
             Mock<IGoogleSheetsGenerator> mockGenerator = new Mock<IGoogleSheetsGenerator>();
             mockGenerator
@@ -446,7 +502,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             Mock<IGoogleSheetsGeneratorFactory> mockFactory = new Mock<IGoogleSheetsGeneratorFactory>();
             mockFactory
-                .Setup(factory => factory.Create(GoogleSheetsType.UCSD))
+                .Setup(factory => factory.Create(type))
                 .Returns(mockGenerator.Object);
 
             this.InitializeHandler(googleSheetsGeneratorFactory: mockFactory.Object);
@@ -457,7 +513,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 await action.SetTeamRolePrefixAsync(DefaultGuildId, TeamRolePrefix);
             }
 
-            await this.Handler.SetRostersFromRolesForUCSD("this URL does not parse");
+            await setRosters("this URL does not parse");
 
             this.MessageStore.VerifyChannelMessages(
                 "The link to the Google Sheet wasn't understandable. Be sure to copy the full URL from the address bar.");
@@ -513,7 +569,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 this.botConfigurationfactory);
             this.GoogleSheetsGeneratorFactory = googleSheetsGeneratorFactory ?? (new Mock<IGoogleSheetsGeneratorFactory>()).Object;
 
-            this.Handler = new AdminCommandHandler(commandContext, options, dbActionFactory, this.GoogleSheetsGeneratorFactory);
+            this.Handler = new AdminCommandHandler(commandContext, dbActionFactory, this.GoogleSheetsGeneratorFactory);
         }
     }
 }

--- a/QuizBowlDiscordScoreTrackerUnitTests/GeneralCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/GeneralCommandHandlerTests.cs
@@ -1428,7 +1428,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             Assert.AreEqual(FirstTeamName, await teamManager.GetTeamIdOrNull(userId), "User didn't join the team");
             this.MessageStore.VerifyChannelMessages($@"@User_{userId} is on team ""{FirstTeamName}""");
         }
-        
+
         [TestMethod]
         public async Task JoinNonexistentTeamFails()
         {

--- a/QuizBowlDiscordScoreTrackerUnitTests/SpreadsheetColumnTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/SpreadsheetColumnTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using QuizBowlDiscordScoreTracker.Scoresheet;
+
+namespace QuizBowlDiscordScoreTrackerUnitTests
+{
+    [TestClass]
+    public class SpreadsheetColumnTests
+    {
+        [TestMethod]
+        public void ThrowIfLessThanOne()
+        {
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new SpreadsheetColumn(0));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new SpreadsheetColumn(-1));
+        }
+
+        [TestMethod]
+        public void ThrowIfGreaterThanLimit()
+        {
+            Assert.ThrowsException<ArgumentOutOfRangeException>(
+                () => new SpreadsheetColumn(SpreadsheetColumn.MaximumColumnNumber + 1));
+        }
+
+        [TestMethod]
+        public void MaximumLimit()
+        {
+            SpreadsheetColumn column = new SpreadsheetColumn(SpreadsheetColumn.MaximumColumnNumber);
+            Assert.AreEqual("ZZ", column.ToString(), "Unexpected column");
+        }
+
+        [TestMethod]
+        public void MinimumLimit()
+        {
+            SpreadsheetColumn column = new SpreadsheetColumn(1);
+            Assert.AreEqual("A", column.ToString(), "Unexpected column");
+        }
+
+        [TestMethod]
+        public void Column27IsAA()
+        {
+            SpreadsheetColumn column = new SpreadsheetColumn(27);
+            Assert.AreEqual("AA", column.ToString(), "Unexpected column");
+        }
+
+        [TestMethod]
+        public void AddTwo()
+        {
+            SpreadsheetColumn column = new SpreadsheetColumn(26);
+            Assert.AreEqual("Z", column.ToString(), "Unexpected column for #26");
+
+            SpreadsheetColumn addition = column + 1;
+            Assert.AreEqual("AA", addition.ToString(), "Unexpected added column");
+        }
+
+        [TestMethod]
+        public void SubtractTwo()
+        {
+            SpreadsheetColumn column = new SpreadsheetColumn(28);
+            Assert.AreEqual("AB", column.ToString(), "Unexpected column for #28");
+
+            SpreadsheetColumn subtraction = column - 2;
+            Assert.AreEqual("Z", subtraction.ToString(), "Unexpected subtracted column");
+        }
+
+        [TestMethod]
+        public void AddPastLimit()
+        {
+            SpreadsheetColumn column = new SpreadsheetColumn(SpreadsheetColumn.MaximumColumnNumber);
+            Assert.AreEqual("ZZ", column.ToString(), "Unexpected column for the limit");
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => column + 1);
+        }
+
+        [TestMethod]
+        public void SubtractPastLimit()
+        {
+            SpreadsheetColumn column = new SpreadsheetColumn(1);
+            Assert.AreEqual("A", column.ToString(), "Unexpected column for #1");
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => column - 1);
+        }
+    }
+}


### PR DESCRIPTION
- Add support for TJ Sheets through these commands
  - setRostersForTJ *sheetsUrl*
    - This requires a team role prefix to be set in the server
  - exportToTJ *sheetsUrl* *round_number*
- Fix bug where guild name was logged twice when a game was stopped
- Add tests for !reloadTeamRoles
- Bump version to 3.7.0