### PR TITLE
Version 3.7.1: bugfixes for exports

### DIFF
--- a/QuizBowlDiscordScoreTracker/Commands/ReaderCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/ReaderCommandHandler.cs
@@ -313,7 +313,6 @@ namespace QuizBowlDiscordScoreTracker.Commands
                 return;
             }
 
-            // TODO: To handle cases where we partially write the scoresheet, we should use something from the result.
             await this.Context.Channel.SendMessageAsync(result.Value);
         }
 

--- a/QuizBowlDiscordScoreTracker/Commands/ReaderCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/ReaderCommandHandler.cs
@@ -314,7 +314,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
             }
 
             // TODO: To handle cases where we partially write the scoresheet, we should use something from the result.
-            await this.Context.Channel.SendMessageAsync($"Game written to the scoresheet Round {round}");
+            await this.Context.Channel.SendMessageAsync(result.Value);
         }
 
         [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings",
@@ -370,7 +370,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
                 return;
             }
 
-            await this.Context.Channel.SendMessageAsync($"Game written to the scoresheet Round {round}");
+            await this.Context.Channel.SendMessageAsync(result.Value);
         }
 
         public async Task SetNewReaderAsync(IGuildUser newReader)

--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.7.0</Version>
+    <Version>3.7.1</Version>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Company />
     <Product>Quiz Bowl Discord Score Tracker</Product>

--- a/QuizBowlDiscordScoreTracker/Scoresheet/BaseGoogleSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/BaseGoogleSheetsGenerator.cs
@@ -144,7 +144,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
             }
 
             IResult<string> updateResult = await this.SheetsApi.UpdateGoogleSheet(
-                ranges, this.GetClearRangesForBonus(sheetName), sheetsUri);
+                ranges, this.GetClearRanges(sheetName), sheetsUri);
             if (!updateResult.Success)
             {
                 return updateResult;
@@ -194,7 +194,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
             return await this.SheetsApi.UpdateGoogleSheet(rangesResult.Value, this.ClearRostersRanges, sheetsUri);
         }
 
-        protected abstract List<string> GetClearRangesForBonus(string sheetName);
+        protected abstract List<string> GetClearRanges(string sheetName);
 
         protected abstract string GetSheetName(int roundNumber);
 

--- a/QuizBowlDiscordScoreTracker/Scoresheet/ExcelFileScoresheetGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/ExcelFileScoresheetGenerator.cs
@@ -9,16 +9,15 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
 {
     public class ExcelFileScoresheetGenerator : IFileScoresheetGenerator
     {
-        // TODO: Support tiebreakers in this packet. This will require skipping one row, then potentially filling in the
-        // next three.
         internal const int PlayersPerTeamLimit = 6;
-        internal const int PhasesLimit = 24;
+        internal const int PhasesLimit = 28;
+        internal const int FirstPhaseRow = 8;
+        internal const int LastBonusRow = 31;
 
         private const int RoomRow = 2;
         private const int ModeratorRow = 3;
         private const int TeamNameRow = 6;
         private const int PlayerNameRow = 7;
-        private const int FirstPhaseRow = 8;
         private const string TemplateFilename = "naqt-scoresheet-electronic-template.xlsx";
         private static readonly string TemplateFile = Path.Combine("Scoresheet", TemplateFilename);
 
@@ -52,7 +51,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
                 (phaseScoresCount == PhasesLimit + 1 && phaseScores.Last().ScoringSplitsOnActions.Any()))
             {
                 return new FailureResult<Stream>(
-                    "Export only currently works if there are at most 24 tosusps answered in a game.");
+                    $"Export only currently works if there are at most {ExcelFileScoresheetGenerator.PhasesLimit} tosusps answered in a game.");
             }
 
             // Copy the file to a stream, so we don't have the handle open the whole time. We may want to cache this
@@ -102,7 +101,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
                         worksheet.Cell(row, column).Value = action.Action.Score;
                     }
 
-                    if (phaseScore.BonusScores?.Any() == true)
+                    if (row <= LastBonusRow && phaseScore.BonusScores?.Any() == true)
                     {
                         int bonusPartCount = phaseScore.BonusScores.Count();
                         if (bonusPartCount != 3)
@@ -124,6 +123,12 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
                             worksheet.Cell(row, bonusColumn).Value = score;
                             bonusColumn++;
                         }
+                    }
+
+                    // After the last bonus row, we skip one row to account for the divider
+                    if (row == LastBonusRow)
+                    {
+                        row++;
                     }
 
                     row++;

--- a/QuizBowlDiscordScoreTracker/Scoresheet/TJSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/TJSheetsGenerator.cs
@@ -79,7 +79,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
             return $"ROUND {roundNumber}";
         }
 
-        protected override List<string> GetClearRangesForBonus(string sheetName)
+        protected override List<string> GetClearRanges(string sheetName)
         {
             // We want to include all the player columns, and the bonus column, so don't include - 1
             int columnsAfterInitial = this.PlayersPerTeamLimit;
@@ -89,6 +89,13 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
                 // player already.
                 $"'{sheetName}'!{StartingColumnsArray.Span[0]}4:{StartingColumnsArray.Span[0] + columnsAfterInitial}27",
                 $"'{sheetName}'!{StartingColumnsArray.Span[1]}4:{StartingColumnsArray.Span[1] + columnsAfterInitial}27",
+
+                // Clear the second team name; the first should always be overwritten
+                $"'{sheetName}'!{this.StartingColumns.Span[1]}{TeamNameRow}:{this.StartingColumns.Span[1]}{TeamNameRow}",
+
+                // Clear player names too, but subtract one, since we don't include the bonus row
+                $"'{sheetName}'!{this.StartingColumns.Span[0]}{PlayerNameRow}:{this.StartingColumns.Span[0] + columnsAfterInitial - 1}{PlayerNameRow}",
+                $"'{sheetName}'!{this.StartingColumns.Span[1]}{PlayerNameRow}:{this.StartingColumns.Span[1] + columnsAfterInitial - 1}{PlayerNameRow}",
             };
         }
 

--- a/QuizBowlDiscordScoreTracker/Scoresheet/TJSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/TJSheetsGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Google.Apis.Sheets.v4.Data;
 
@@ -124,7 +125,13 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
                     .FirstOrDefault(split => split.Action.Score > 0);
                 if (split != null)
                 {
-                    int bonusIndex = Array.IndexOf(teamIds, split.Action.Buzz.TeamId);
+                    // TODO: See if there's a better way to get the individual's team (add it when we add the buzz?)
+                    // Risk is if there's a team name that is the same as someone's ID
+                    // If it's an individual who is a team, then the teamId will be null, but their user ID may be a
+                    // team ID.
+                    int bonusIndex = Array.IndexOf(
+                        teamIds, 
+                        split.Action.Buzz.TeamId ?? split.Action.Buzz.UserId.ToString(CultureInfo.InvariantCulture));
                     if (bonusIndex < 0 || bonusIndex >= 2)
                     {
                         return new FailureResult<IEnumerable<ValueRange>>(

--- a/QuizBowlDiscordScoreTracker/Scoresheet/UCSDGoogleSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/UCSDGoogleSheetsGenerator.cs
@@ -131,7 +131,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
             return new SuccessResult<IEnumerable<ValueRange>>(ranges);
         }
 
-        protected override List<string> GetClearRangesForBonus(string sheetName)
+        protected override List<string> GetClearRanges(string sheetName)
         {
             int columnsAfterInitial = this.PlayersPerTeamLimit - 1;
             return new List<string>()
@@ -140,6 +140,13 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
                 // player already.
                 $"'{sheetName}'!{this.StartingColumns.Span[0]}4:{this.StartingColumns.Span[0] + columnsAfterInitial}31",
                 $"'{sheetName}'!{this.StartingColumns.Span[1]}4:{this.StartingColumns.Span[1] + columnsAfterInitial}31",
+
+                // Clear the second team name; the first should always be overwritten
+                $"'{sheetName}'!{this.StartingColumns.Span[1]}{TeamNameRow}:{this.StartingColumns.Span[1]}{TeamNameRow}",
+
+                // Clear player names too
+                $"'{sheetName}'!{this.StartingColumns.Span[0]}{PlayerNameRow}:{this.StartingColumns.Span[0] + columnsAfterInitial}{PlayerNameRow}",
+                $"'{sheetName}'!{this.StartingColumns.Span[1]}{PlayerNameRow}:{this.StartingColumns.Span[1] + columnsAfterInitial}{PlayerNameRow}",
             };
         }
     }

--- a/QuizBowlDiscordScoreTrackerUnitTests/ReaderCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/ReaderCommandHandlerTests.cs
@@ -24,6 +24,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
     {
         private const ulong DefaultReaderId = 1;
         private static readonly HashSet<ulong> DefaultIds = new HashSet<ulong>(new ulong[] { 1, 2, 3 });
+        private static readonly string MockTryCreateScoresheetMessage = Guid.NewGuid().ToString();
 
         private const ulong DefaultChannelId = 11;
         private const ulong DefaultGuildId = 9;
@@ -880,7 +881,8 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             Mock<IGoogleSheetsGenerator> mockGenerator = new Mock<IGoogleSheetsGenerator>();
             mockGenerator
                 .Setup(generator => generator.TryCreateScoresheet(It.IsAny<GameState>(), It.IsAny<Uri>(), It.IsAny<int>()))
-                .Returns(Task.FromResult<IResult<string>>(new SuccessResult<string>(string.Empty)))
+                .Returns<GameState, Uri, int>((game, uri, round) => Task.FromResult<IResult<string>>(new SuccessResult<string>(
+                    $"{MockTryCreateScoresheetMessage}{round}")))
                 .Verifiable();
 
             Mock<IGoogleSheetsGeneratorFactory> mockFactory = new Mock<IGoogleSheetsGeneratorFactory>();
@@ -892,13 +894,13 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             await exportToSheet("https://localhost/sheetsUrl", 1);
 
             mockFactory.Verify();
-            this.MessageStore.VerifyChannelMessages("Game written to the scoresheet Round 1");
+            this.MessageStore.VerifyChannelMessages($"{MockTryCreateScoresheetMessage}1");
 
             // Make sure it succeeds at the limit (15) too
             this.MessageStore.Clear();
             await exportToSheet("https://localhost/sheetsUrl", 15);
 
-            this.MessageStore.VerifyChannelMessages("Game written to the scoresheet Round 15");
+            this.MessageStore.VerifyChannelMessages($"{MockTryCreateScoresheetMessage}15");
         }
 
         private async Task ExportToGoogleSheetsUserLimit(GoogleSheetsType type, Func<string, int, Task> exportToSheet)
@@ -909,7 +911,8 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             Mock<IGoogleSheetsGenerator> mockGenerator = new Mock<IGoogleSheetsGenerator>();
             mockGenerator
                 .Setup(generator => generator.TryCreateScoresheet(It.IsAny<GameState>(), It.IsAny<Uri>(), It.IsAny<int>()))
-                .Returns(Task.FromResult<IResult<string>>(new SuccessResult<string>(string.Empty)));
+                .Returns<GameState, Uri, int>((game, uri, round) => Task.FromResult<IResult<string>>(
+                    new SuccessResult<string>($"{MockTryCreateScoresheetMessage}{round}")));
 
             Mock<IGoogleSheetsGeneratorFactory> mockFactory = new Mock<IGoogleSheetsGeneratorFactory>();
             mockFactory
@@ -921,7 +924,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             for (int i = 0; i < userLimit; i++)
             {
                 await exportToSheet("https://localhost/sheetsUrl", i + 1);
-                this.MessageStore.VerifyChannelMessages($"Game written to the scoresheet Round {i + 1}");
+                this.MessageStore.VerifyChannelMessages($"{MockTryCreateScoresheetMessage}{i + 1}");
                 this.MessageStore.Clear();
             }
 
@@ -944,7 +947,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             Mock<IGoogleSheetsGenerator> mockGenerator = new Mock<IGoogleSheetsGenerator>();
             mockGenerator
                 .Setup(generator => generator.TryCreateScoresheet(It.IsAny<GameState>(), It.IsAny<Uri>(), It.IsAny<int>()))
-                .Returns(Task.FromResult<IResult<string>>(new SuccessResult<string>(string.Empty)));
+                .Returns(Task.FromResult<IResult<string>>(new SuccessResult<string>(MockTryCreateScoresheetMessage)));
 
             Mock<IGoogleSheetsGeneratorFactory> mockFactory = new Mock<IGoogleSheetsGeneratorFactory>();
             mockFactory
@@ -956,7 +959,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             for (int i = 0; i < guildLimit; i++)
             {
                 await exportToSheet("https://localhost/sheetsUrl", i + 1);
-                this.MessageStore.VerifyChannelMessages($"Game written to the scoresheet Round {i + 1}");
+                this.MessageStore.VerifyChannelMessages(MockTryCreateScoresheetMessage);
                 this.MessageStore.Clear();
             }
 
@@ -978,7 +981,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             Mock<IGoogleSheetsGenerator> mockGenerator = new Mock<IGoogleSheetsGenerator>();
             mockGenerator
                 .Setup(generator => generator.TryCreateScoresheet(It.IsAny<GameState>(), It.IsAny<Uri>(), It.IsAny<int>()))
-                .Returns(Task.FromResult<IResult<string>>(new SuccessResult<string>(string.Empty)));
+                .Returns(Task.FromResult<IResult<string>>(new SuccessResult<string>(MockTryCreateScoresheetMessage)));
 
             Mock<IGoogleSheetsGeneratorFactory> mockFactory = new Mock<IGoogleSheetsGeneratorFactory>();
             mockFactory
@@ -1000,7 +1003,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             Mock<IGoogleSheetsGenerator> mockGenerator = new Mock<IGoogleSheetsGenerator>();
             mockGenerator
                 .Setup(generator => generator.TryCreateScoresheet(It.IsAny<GameState>(), It.IsAny<Uri>(), It.IsAny<int>()))
-                .Returns(Task.FromResult<IResult<string>>(new SuccessResult<string>(string.Empty)));
+                .Returns(Task.FromResult<IResult<string>>(new SuccessResult<string>(MockTryCreateScoresheetMessage)));
 
             Mock<IGoogleSheetsGeneratorFactory> mockFactory = new Mock<IGoogleSheetsGeneratorFactory>();
             mockFactory

--- a/QuizBowlDiscordScoreTrackerUnitTests/TJSheetsGeneratorTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/TJSheetsGeneratorTests.cs
@@ -144,6 +144,11 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             Assert.IsTrue(this.ClearedRanges.Contains("'ROUND 1'!C4:I27"), "First team scores are not in the list of cleared ranges.");
             Assert.IsTrue(this.ClearedRanges.Contains("'ROUND 1'!M4:S27"), "Second team scores are not in the list of cleared ranges.");
 
+            // Assert we cleared the second team and the players
+            Assert.IsTrue(this.ClearedRanges.Contains("'ROUND 1'!M2:M2"), "Second team name wasn't cleared");
+            Assert.IsTrue(this.ClearedRanges.Contains("'ROUND 1'!C3:H3"), "First team's player names weren't cleared");
+            Assert.IsTrue(this.ClearedRanges.Contains("'ROUND 1'!M3:R3"), "Second team's player names weren't cleared");
+
             // These checks are O(n^2), since we do Any for all of them. However, n is small here (~15), so it's not
             // too bad.
 

--- a/QuizBowlDiscordScoreTrackerUnitTests/TJSheetsGeneratorTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/TJSheetsGeneratorTests.cs
@@ -420,12 +420,51 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             Assert.IsTrue(
                 this.TeamManager.TryAddPlayerToTeam(1111, "OverLimit", FirstTeam),
                 "Adding the player over the limit should've succeeded");
+
+            // We need to force an update to the game, so we don't have cached stats
+            await game.AddPlayer(2, "Player2");
+            game.ScorePlayer(0);
+
             result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
             Assert.IsFalse(result.Success, $"Creation should've failed after the limit.");
             Assert.AreEqual(
                 $"Couldn't write to the sheet. Export only currently works if there are at most {this.Generator.PlayersPerTeamLimit} players on a team.",
                 result.ErrorMessage,
                 "Unexpected error message");
+        }
+
+        [TestMethod]
+        public async Task TryCreateScoresheetOneTeamAndIndividual()
+        {
+            const string firstTeamPlayer = "Alice";
+            const string individualName = "Individual";
+
+            GameState game = new GameState()
+            {
+                Format = Format.TossupShootout,
+                ReaderId = 1,
+                TeamManager = this.TeamManager
+            };
+
+            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the team");
+            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(2, firstTeamPlayer, FirstTeam), "Couldn't add player to team");
+
+            await game.AddPlayer(2, firstTeamPlayer);
+            game.ScorePlayer(10);
+            await game.AddPlayer(3, individualName);
+            game.ScorePlayer(15);
+
+            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
+            Assert.IsTrue(result.Success, $"Creation should've succeeded");
+
+            // n^2 runtime, but not that many checks or update ranges, so it should be okay
+
+            this.AssertInUpdateRange($"'ROUND 1'!C2", FirstTeam, "Couldn't find the first team's name");
+            this.AssertInUpdateRange($"'ROUND 1'!M2", individualName, "Couldn't find the second team's name");
+            this.AssertInUpdateRange($"'ROUND 1'!C3", firstTeamPlayer, "Couldn't find the first team's player name");
+            this.AssertInUpdateRange($"'ROUND 1'!M3", individualName, "Couldn't find the indivual team's player name");
+            this.AssertInUpdateRange($"'ROUND 1'!C4", "10", "Couldn't find the buzz from the first team");
+            this.AssertInUpdateRange($"'ROUND 1'!M5", "15", "Couldn't find the buzz from the individual team");
         }
 
         [TestMethod]
@@ -451,13 +490,15 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             Assert.IsTrue(result.Success, $"Creation should've succeeded at the limit.");
 
             await game.AddPlayer(2, "Alice");
-            game.ScorePlayer(10);
+            game.ScorePlayer(15);
+
             result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
-            Assert.IsFalse(result.Success, $"Creation should've failed after the limit.");
-            Assert.AreEqual(
-                $"Couldn't write to the sheet. Export only currently works if there are at most {this.Generator.PhasesLimit} tosusps answered in a game. Bonuses will only be tracked up to question {this.Generator.LastBonusRow - this.Generator.FirstPhaseRow + 1}.",
-                result.ErrorMessage,
-                "Unexpected error message");
+            Assert.IsTrue(result.Success, $"Creation should've succeeded.");            
+            this.AssertInUpdateRange($"'ROUND 1'!C27", "10", "Couldn't find the last buzz");
+            Assert.IsFalse(
+                this.UpdatedRanges
+                    .Any(valueRange => valueRange.Values.Any(v => v.ToString() == "15")),
+                "Last buzz should've been cut off, but we found a power");
         }
 
         [TestMethod]

--- a/QuizBowlDiscordScoreTrackerUnitTests/UCSDGoogleSheetsGeneratorTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/UCSDGoogleSheetsGeneratorTests.cs
@@ -131,8 +131,13 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             Assert.IsTrue(result.Success, $"Failed: {(result.Success ? "" : result.ErrorMessage)}");
 
             // Assert we cleared these two fields
-            Assert.IsTrue(this.ClearedRanges.Contains("'Round 1'!C4:H31"), "First team scores are not in the list of cleared ranges.");
-            Assert.IsTrue(this.ClearedRanges.Contains("'Round 1'!O4:T31"), "Second team scores are not in the list of cleared ranges.");
+            Assert.IsTrue(this.ClearedRanges.Contains("'Round 1'!C4:H31"), "First team scores are not in the list of cleared ranges");
+            Assert.IsTrue(this.ClearedRanges.Contains("'Round 1'!O4:T31"), "Second team scores are not in the list of cleared ranges");
+
+            // Assert we cleared the second team and the players
+            Assert.IsTrue(this.ClearedRanges.Contains("'Round 1'!O1:O1"), "Second team name wasn't cleared");
+            Assert.IsTrue(this.ClearedRanges.Contains("'Round 1'!C3:H3"), "First team's player names weren't cleared");
+            Assert.IsTrue(this.ClearedRanges.Contains("'Round 1'!O3:T3"), "Second team's player names weren't cleared");
 
             // These checks are O(n^2), since we do Any for all of them. However, n is small here (~15), so it's not
             // too bad.


### PR DESCRIPTION
- Support tiebreakers for the exported file (NAQT) scoresheet (#76)
- We no longer fail to write a TJ/UCSD scoresheet if there are too many phases. We write what we can and alert the user that the output is trimmed (#71) 
- Fix an issue where TJ/UCSD scoresheets wouldn't be written if one of the teams was just an individual (and not a registered team) (#74) 
- If !next is used during a bonus, clear the scoring cache, since a bonus is scored
- Fix bug where player/team names weren't cleared when updating Google Sheets
- Bump version to 3.7.1