### PR TITLE
Merged PR 144: Version 3.7.2 - !help and !undo fixes

### DIFF
--- a/QuizBowlDiscordScoreTracker/Commands/HelpCommand.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/HelpCommand.cs
@@ -39,7 +39,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
             IEnumerable<CommandInfo> commands = this.commandService.Commands.Where(command => command.Name != "help");
             string commandName = rawCommandName.Trim();
             commands = commands
-                .Where(command => command.Name.Equals(commandName, StringComparison.CurrentCultureIgnoreCase));
+                .Where(command => command.Name.Contains(commandName, StringComparison.CurrentCultureIgnoreCase));
 
             bool userIsBotOwner = this.Context.User.Id == (await this.Context.Client.GetApplicationInfoAsync()).Owner.Id;
             if (!userIsBotOwner)
@@ -103,7 +103,8 @@ namespace QuizBowlDiscordScoreTracker.Commands
             {
                 Title = "How to play",
                 Color = Color.Gold,
-                Description = "1. The reader should use the !read command.\n" +
+                Description = "Visit [the wiki](https://github.com/alopezlago/QuizBowlDiscordScoreTracker/wiki) or [the official server](https://discord.gg/s2nRnKRFpd) for more information.\n\n" +
+                    "1. The reader should use the !read command.\n" +
                     "2. When a player wants to buzz in, they should type in \"buzz\" (near equivalents like \"bzz\" are acceptable).\n" +
                     "3. The reader scores the buzz by typing in the value (-5, 0, 10, 15, 20).\n" +
                     "4. If someone gets the question correct, the buzz queue is cleared. If no one answers the question, then use the !next command to clear the queue and start the next question.\n" +

--- a/QuizBowlDiscordScoreTracker/Commands/ReaderCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/ReaderCommandHandler.cs
@@ -461,10 +461,18 @@ namespace QuizBowlDiscordScoreTracker.Commands
                 return;
             }
 
-            if (nextUserId == null && game.CurrentStage == PhaseStage.Bonus)
+            if (nextUserId == null)
             {
-                await this.Context.Channel.SendMessageAsync($"**Bonus for TU {game.PhaseNumber}**");
-                return;
+                if (game.CurrentStage == PhaseStage.Bonus)
+                {
+                    await this.Context.Channel.SendMessageAsync($"**Bonus for TU {game.PhaseNumber}**");
+                    return;
+                }
+                else
+                {
+                    await this.Context.Channel.SendMessageAsync($"**TU {game.PhaseNumber}**");
+                    return;
+                }
             }
 
             ulong userId = nextUserId.Value;

--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.7.1</Version>
+    <Version>3.7.2</Version>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Company />
     <Product>Quiz Bowl Discord Score Tracker</Product>

--- a/QuizBowlDiscordScoreTrackerUnitTests/ReaderCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/ReaderCommandHandlerTests.cs
@@ -240,6 +240,46 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
+        public async Task UndoAfterNextQuestionOnBonusStagePromptsForBonus()
+        {
+            ulong buzzer = GetExistingNonReaderUserId();
+            this.InitializeHandler();
+            this.Game.Format = Format.TossupBonusesShootout;
+
+            this.Game.ReaderId = DefaultReaderId;
+            await this.Game.AddPlayer(buzzer, "Player");
+            this.Game.ScorePlayer(10);
+            this.Game.NextQuestion();
+            await this.Handler.UndoAsync();
+
+            Assert.AreEqual(PhaseStage.Bonus, this.Game.CurrentStage, "We should be in the bonus stage");
+            Assert.AreEqual(1, this.Game.PhaseNumber, "We should be back to the first question");
+            Assert.AreEqual(1, this.MessageStore.ChannelMessages.Count, "Unexpected number of channel messages.");
+            string message = this.MessageStore.ChannelMessages.First();
+            Assert.AreEqual(
+                "**Bonus for TU 1**", message, "Mention should be included in undo message as a prompt.");
+        }
+
+        [TestMethod]
+        public async Task UndoAfterNextQuestionOnTossupStagePromptsForTossup()
+        {
+            ulong buzzer = GetExistingNonReaderUserId();
+            this.InitializeHandler();
+            this.Game.Format = Format.TossupBonusesShootout;
+
+            this.Game.ReaderId = DefaultReaderId;
+            this.Game.NextQuestion();
+            await this.Handler.UndoAsync();
+
+            Assert.AreEqual(PhaseStage.Tossup, this.Game.CurrentStage, "We should be in the tossup stage");
+            Assert.AreEqual(1, this.Game.PhaseNumber, "We should be back to the first question");
+            Assert.AreEqual(1, this.MessageStore.ChannelMessages.Count, "Unexpected number of channel messages.");
+            string message = this.MessageStore.ChannelMessages.First();
+            Assert.AreEqual(
+                "**TU 1**", message, "Mention should be included in undo message as a prompt.");
+        }
+
+        [TestMethod]
         public async Task SkipBuzzerNoLongerInServerOnUndo()
         {
             ulong buzzer = GetExistingNonReaderUserId();


### PR DESCRIPTION
- Have `!help` link to the wiki and to a Discord help server
- `!help *command*` now uses Contains instead of Equals, so it can return more results
- Change the behavior of `!undo` to only undo one instance of `!nextQuestion` instead of all consecutive instances (#72)
- Bump version to 3.7.2