### PR TITLE
v3.8.0

### DIFF
--- a/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/AdminCommands.cs
@@ -54,11 +54,27 @@ namespace QuizBowlDiscordScoreTracker.Commands
             return this.GetHandler().DisableBonusesByDefaultAsync();
         }
 
+        [Command("disableBuzzQueue")]
+        [Summary("Ensures that the bot will not queue buzzes, so it will only recognize and remember the buzzer it " +
+            "prompted. Players whose buzz was not recognized must buzz in again after the reader scores the current player.")]
+        public Task DisableBuzzQueueAsync()
+        {
+            return this.GetHandler().DisableBuzzQueueAsync();
+        }
+
         [Command("enableBonusesByDefault")]
         [Summary("Makes scoring bonuses in a game enabled by default in this server.")]
         public Task EnableBonusesAsync()
         {
             return this.GetHandler().EnableBonusesByDefaultAsync();
+        }
+
+        [Command("enableBuzzQueue")]
+        [Summary("Ensures that the bot will queue buzzes. Players only need to buzz once, and they will be recognized " +
+            "in the order they buzzed in.")]
+        public Task EnableBuzzQueueAsync()
+        {
+            return this.GetHandler().EnableBuzzQueueAsync();
         }
 
         [Command("getPairedChannel")]

--- a/QuizBowlDiscordScoreTracker/Database/BotConfigurationContext.cs
+++ b/QuizBowlDiscordScoreTracker/Database/BotConfigurationContext.cs
@@ -13,7 +13,7 @@ namespace QuizBowlDiscordScoreTracker.Database
     // dotnet ef database update
     //
     // To perform migrations with Visual Studio (Package Manager Console)
-    // Add-Migration InitialCreate
+    // Add-Migration <name of migration>
     // Update-Database
     //
     // When you migrate, consult the site below to make sure migrations are safe.

--- a/QuizBowlDiscordScoreTracker/Database/DatabaseAction.cs
+++ b/QuizBowlDiscordScoreTracker/Database/DatabaseAction.cs
@@ -82,6 +82,12 @@ namespace QuizBowlDiscordScoreTracker.Database
             return user?.CommandBanned ?? false;
         }
 
+        public async Task<bool> GetDisabledBuzzQueueAsync(ulong guildId)
+        {
+            GuildSetting guild = await this.Context.FindAsync<GuildSetting>(guildId);
+            return guild?.DisableBuzzQueue ?? false;
+        }
+
         public async Task<ulong?> GetPairedVoiceChannelIdOrNullAsync(ulong textChannelId)
         {
             TextChannelSetting textChannel = await this.Context.FindAsync<TextChannelSetting>(textChannelId);
@@ -100,13 +106,13 @@ namespace QuizBowlDiscordScoreTracker.Database
             return guild?.TeamRolePrefix ?? null;
         }
 
-        public async Task<bool> GetUseBonuses(ulong guildId)
+        public async Task<bool> GetUseBonusesAsync(ulong guildId)
         {
             GuildSetting guild = await this.Context.FindAsync<GuildSetting>(guildId);
             return guild?.UseBonuses ?? false;
         }
 
-        public async Task<int> GetGuildExportCount(ulong guildId)
+        public async Task<int> GetGuildExportCountAsync(ulong guildId)
         {
             GuildSetting guild = await this.AddOrGetGuildAsync(guildId);
             int currentDay = DateTime.UtcNow.Day;
@@ -120,7 +126,7 @@ namespace QuizBowlDiscordScoreTracker.Database
             return guild.ExportCount;
         }
 
-        public async Task<int> GetUserExportCount(ulong userId)
+        public async Task<int> GetUserExportCountAsync(ulong userId)
         {
             UserSetting user = await this.AddOrGetUserAsync(userId);
             int currentDay = DateTime.UtcNow.Day;
@@ -134,7 +140,7 @@ namespace QuizBowlDiscordScoreTracker.Database
             return user.ExportCount;
         }
 
-        public async Task IncrementGuildExportCount(ulong guildId)
+        public async Task IncrementGuildExportCountAsync(ulong guildId)
         {
             GuildSetting guild = await this.AddOrGetGuildAsync(guildId);
             int currentDay = DateTime.UtcNow.Day;
@@ -151,7 +157,7 @@ namespace QuizBowlDiscordScoreTracker.Database
             await this.Context.SaveChangesAsync();
         }
 
-        public async Task IncrementUserExportCount(ulong userId)
+        public async Task IncrementUserExportCountAsync(ulong userId)
         {
             UserSetting user = await this.AddOrGetUserAsync(userId);
             int currentDay = DateTime.UtcNow.Day;
@@ -194,6 +200,13 @@ namespace QuizBowlDiscordScoreTracker.Database
             UserSetting user = await this.AddOrGetUserAsync(userId);
             user.CommandBanned = false;
             this.RemoveUserIfEmptyAsync(user);
+            await this.Context.SaveChangesAsync();
+        }
+
+        public async Task SetDisableBuzzQueueAsync(ulong guildId, bool isDisabled)
+        {
+            GuildSetting guild = await this.AddOrGetGuildAsync(guildId);
+            guild.DisableBuzzQueue = isDisabled;
             await this.Context.SaveChangesAsync();
         }
 
@@ -296,6 +309,7 @@ namespace QuizBowlDiscordScoreTracker.Database
             if (guild.TeamRolePrefix != null ||
                 guild.ReaderRolePrefix != null ||
                 guild.UseBonuses ||
+                guild.DisableBuzzQueue ||
                 (guild.ExportCount > 0 && guild.LastExportDay == DateTime.UtcNow.Day))
             {
                 return;

--- a/QuizBowlDiscordScoreTracker/Database/GuildSetting.cs
+++ b/QuizBowlDiscordScoreTracker/Database/GuildSetting.cs
@@ -13,6 +13,8 @@ namespace QuizBowlDiscordScoreTracker.Database
         public int ExportCount { get; set; }
         public int LastExportDay { get; set; }
 
+        public bool DisableBuzzQueue { get; set; }
+
 #pragma warning disable CA2227 // Collection properties should be read only. This is an EF Core model class; the collection must be settable
         public ICollection<TextChannelSetting> TextChannels { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only

--- a/QuizBowlDiscordScoreTracker/Format.cs
+++ b/QuizBowlDiscordScoreTracker/Format.cs
@@ -2,42 +2,64 @@
 {
     public class Format
     {
-        // This controls the format for games. Acf is unused for now, but will be used when we support a touranment mode
-        public static readonly Format Acf = new Format()
-        {
-            HighestPhaseIndexWithBonus = 20 - 1,
-            PhasesInRegulation = 20
-        };
-
-        public static readonly Format TossupShootout = new Format()
-        {
-            // No bonuses in a tossup shootout
-            HighestPhaseIndexWithBonus = -1,
-            PhasesInRegulation = int.MaxValue
-        };
-
-        public static readonly Format TossupBonusesShootout = new Format()
-        {
-            HighestPhaseIndexWithBonus = int.MaxValue,
-            PhasesInRegulation = int.MaxValue
-        };
-
         public int HighestPhaseIndexWithBonus { get; set; }
 
         public int PhasesInRegulation { get; set; }
 
+        public bool DisableBuzzQueue { get; set; }
+
         // TODO: Add information to handle tiebreakers
         // TODO: See if we can match the QB Schema to handle most cases
+
+        public static Format CreateTossupShootout(bool disableBuzzQueue)
+        {
+            return new Format()
+            {
+                // No bonuses in a tossup shootout
+                HighestPhaseIndexWithBonus = -1,
+                PhasesInRegulation = int.MaxValue,
+                DisableBuzzQueue = disableBuzzQueue
+            };
+        }
+
+        public static Format CreateTossupBonusesShootout(bool disableBuzzQueue)
+        {
+            return new Format()
+            {
+                HighestPhaseIndexWithBonus = int.MaxValue,
+                PhasesInRegulation = int.MaxValue,
+                DisableBuzzQueue = disableBuzzQueue
+            };
+        }
 
         // TODO: We may need the team scores to determine if we have more phases. Move to a TryCreate pattern then?
         public IPhaseState CreateNextPhase(int phaseIndex)
         {
             if (phaseIndex > this.HighestPhaseIndexWithBonus)
             {
-                return new TossupOnlyPhaseState();
+                return new TossupOnlyPhaseState(this.DisableBuzzQueue);
             }
 
-            return new TossupBonusPhaseState();
+            return new TossupBonusPhaseState(this.DisableBuzzQueue);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Format other))
+            {
+                return false;
+            }
+
+            return this.DisableBuzzQueue == other.DisableBuzzQueue &&
+                this.HighestPhaseIndexWithBonus == other.HighestPhaseIndexWithBonus &&
+                this.PhasesInRegulation == other.PhasesInRegulation;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.DisableBuzzQueue.GetHashCode() ^
+                this.HighestPhaseIndexWithBonus.GetHashCode() ^
+                this.PhasesInRegulation.GetHashCode();
         }
     }
 }

--- a/QuizBowlDiscordScoreTracker/GameState.cs
+++ b/QuizBowlDiscordScoreTracker/GameState.cs
@@ -28,12 +28,12 @@ namespace QuizBowlDiscordScoreTracker
         private readonly object phasesLock = new object();
         private readonly object readerLock = new object();
 
-        public GameState()
+        public GameState(bool disableBuzzQueue = false)
         {
             this.phases = new LinkedList<IPhaseState>();
             this.cachedLastScoringSplit = null;
             this.cachedPhaseScoresPerPhase = null;
-            this.format = Format.TossupShootout;
+            this.format = Format.CreateTossupShootout(disableBuzzQueue);
             this.TeamManager = SoloOnlyTeamManager.Instance;
 
             // Generate a 64-bit cryptographically secure random string for the ID

--- a/QuizBowlDiscordScoreTracker/Migrations/20210204001631_DisableBuzzQueue.Designer.cs
+++ b/QuizBowlDiscordScoreTracker/Migrations/20210204001631_DisableBuzzQueue.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QuizBowlDiscordScoreTracker.Database;
 
 namespace QuizBowlDiscordScoreTracker.Migrations
 {
     [DbContext(typeof(BotConfigurationContext))]
-    partial class BotConfigurationContextModelSnapshot : ModelSnapshot
+    [Migration("20210204001631_DisableBuzzQueue")]
+    partial class DisableBuzzQueue
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QuizBowlDiscordScoreTracker/Migrations/20210204001631_DisableBuzzQueue.cs
+++ b/QuizBowlDiscordScoreTracker/Migrations/20210204001631_DisableBuzzQueue.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace QuizBowlDiscordScoreTracker.Migrations
+{
+#pragma warning disable CA1062 // Validate arguments of public methods
+    public partial class DisableBuzzQueue : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "DisableBuzzQueue",
+                table: "Guilds",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DisableBuzzQueue",
+                table: "Guilds");
+        }
+    }
+#pragma warning disable CA1062 // Validate arguments of public methods
+}

--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.7.2</Version>
+    <Version>3.8.0</Version>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Company />
     <Product>Quiz Bowl Discord Score Tracker</Product>

--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.95.3" />
+    <PackageReference Include="ClosedXML" Version="0.95.4" />
     <PackageReference Include="Discord.Net" Version="2.2.0" />
-    <PackageReference Include="Google.Apis.Sheets.v4" Version="1.49.0.2111" />
+    <PackageReference Include="Google.Apis.Sheets.v4" Version="1.49.0.2175" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -13,25 +13,25 @@
 
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.95.4" />
-    <PackageReference Include="Discord.Net" Version="2.2.0" />
+    <PackageReference Include="Discord.Net" Version="2.3.0" />
     <PackageReference Include="Google.Apis.Sheets.v4" Version="1.49.0.2175" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.8" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
   </ItemGroup>

--- a/QuizBowlDiscordScoreTracker/Scoresheet/BaseGoogleSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/BaseGoogleSheetsGenerator.cs
@@ -51,7 +51,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
             }
 
             // Make it an array so we don't keep re-evaluating the enumerable
-            
+
             IReadOnlyDictionary<PlayerTeamPair, LastScoringSplit> players = await game.GetLastScoringSplits();
             IEnumerable<IGrouping<string, PlayerTeamPair>> playersByTeam = players.GroupBy(
                 kvp => kvp.Key.TeamId, kvp => kvp.Key);

--- a/QuizBowlDiscordScoreTracker/Scoresheet/ExcelFileScoresheetGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/ExcelFileScoresheetGenerator.cs
@@ -74,10 +74,12 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
                 worksheet.Cell(ModeratorRow, 2).Value = readerName;
                 worksheet.Cell(ModeratorRow, 12).Value = readerName;
 
-                worksheet.Cell(TeamNameRow, 2).Value = teamIdToNames.Values.First();
+                string firstTeamName = teamIdToNames.GetValueOrDefault(teamIds[0], string.Empty);
+                worksheet.Cell(TeamNameRow, 2).Value = firstTeamName;
                 if (teamIdToNames.Count > 1)
                 {
-                    worksheet.Cell(TeamNameRow, StartingColumns[1]).Value = teamIdToNames.ElementAt(1).Value;
+                    string secondTeamName = teamIdToNames.GetValueOrDefault(teamIds[1], string.Empty);
+                    worksheet.Cell(TeamNameRow, StartingColumns[1]).Value = secondTeamName;
                 }
 
                 foreach (PlayerTeamPair pair in players)

--- a/QuizBowlDiscordScoreTracker/Scoresheet/TJSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/TJSheetsGenerator.cs
@@ -91,11 +91,11 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
                 $"'{sheetName}'!{StartingColumnsArray.Span[1]}4:{StartingColumnsArray.Span[1] + columnsAfterInitial}27",
 
                 // Clear the second team name; the first should always be overwritten
-                $"'{sheetName}'!{this.StartingColumns.Span[1]}{TeamNameRow}:{this.StartingColumns.Span[1]}{TeamNameRow}",
+                $"'{sheetName}'!{this.StartingColumns.Span[1]}{this.TeamNameRow}:{this.StartingColumns.Span[1]}{this.TeamNameRow}",
 
                 // Clear player names too, but subtract one, since we don't include the bonus row
-                $"'{sheetName}'!{this.StartingColumns.Span[0]}{PlayerNameRow}:{this.StartingColumns.Span[0] + columnsAfterInitial - 1}{PlayerNameRow}",
-                $"'{sheetName}'!{this.StartingColumns.Span[1]}{PlayerNameRow}:{this.StartingColumns.Span[1] + columnsAfterInitial - 1}{PlayerNameRow}",
+                $"'{sheetName}'!{this.StartingColumns.Span[0]}{this.PlayerNameRow}:{this.StartingColumns.Span[0] + columnsAfterInitial - 1}{this.PlayerNameRow}",
+                $"'{sheetName}'!{this.StartingColumns.Span[1]}{this.PlayerNameRow}:{this.StartingColumns.Span[1] + columnsAfterInitial - 1}{this.PlayerNameRow}",
             };
         }
 
@@ -137,7 +137,7 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
                     // If it's an individual who is a team, then the teamId will be null, but their user ID may be a
                     // team ID.
                     int bonusIndex = Array.IndexOf(
-                        teamIds, 
+                        teamIds,
                         split.Action.Buzz.TeamId ?? split.Action.Buzz.UserId.ToString(CultureInfo.InvariantCulture));
                     if (bonusIndex < 0 || bonusIndex >= 2)
                     {

--- a/QuizBowlDiscordScoreTracker/Scoresheet/UCSDGoogleSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/UCSDGoogleSheetsGenerator.cs
@@ -142,11 +142,11 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
                 $"'{sheetName}'!{this.StartingColumns.Span[1]}4:{this.StartingColumns.Span[1] + columnsAfterInitial}31",
 
                 // Clear the second team name; the first should always be overwritten
-                $"'{sheetName}'!{this.StartingColumns.Span[1]}{TeamNameRow}:{this.StartingColumns.Span[1]}{TeamNameRow}",
+                $"'{sheetName}'!{this.StartingColumns.Span[1]}{this.TeamNameRow}:{this.StartingColumns.Span[1]}{this.TeamNameRow}",
 
                 // Clear player names too
-                $"'{sheetName}'!{this.StartingColumns.Span[0]}{PlayerNameRow}:{this.StartingColumns.Span[0] + columnsAfterInitial}{PlayerNameRow}",
-                $"'{sheetName}'!{this.StartingColumns.Span[1]}{PlayerNameRow}:{this.StartingColumns.Span[1] + columnsAfterInitial}{PlayerNameRow}",
+                $"'{sheetName}'!{this.StartingColumns.Span[0]}{this.PlayerNameRow}:{this.StartingColumns.Span[0] + columnsAfterInitial}{this.PlayerNameRow}",
+                $"'{sheetName}'!{this.StartingColumns.Span[1]}{this.PlayerNameRow}:{this.StartingColumns.Span[1] + columnsAfterInitial}{this.PlayerNameRow}",
             };
         }
     }

--- a/QuizBowlDiscordScoreTracker/TeamManager/ByCommandTeamManager.cs
+++ b/QuizBowlDiscordScoreTracker/TeamManager/ByCommandTeamManager.cs
@@ -48,11 +48,6 @@ namespace QuizBowlDiscordScoreTracker.TeamManager
             return Task.FromResult(teamId);
         }
 
-        public void ReloadTeamRoles(out string message)
-        {
-            message = $@"Cannot reload team roles.";
-        }
-
         public Task<IReadOnlyDictionary<string, string>> GetTeamIdToNames()
         {
             IReadOnlyDictionary<string, string> teamIdToName = (IReadOnlyDictionary<string, string>)this.TeamIdToName;

--- a/QuizBowlDiscordScoreTracker/TeamManager/SoloOnlyTeamManager.cs
+++ b/QuizBowlDiscordScoreTracker/TeamManager/SoloOnlyTeamManager.cs
@@ -27,9 +27,5 @@ namespace QuizBowlDiscordScoreTracker.TeamManager
             IReadOnlyDictionary<string, string> teamIdToNames = new Dictionary<string, string>();
             return Task.FromResult(teamIdToNames);
         }
-        public void ReloadTeamRoles(out string message)
-        {
-            message = $@"Cannot reload team roles.";
-        }
     }
 }

--- a/QuizBowlDiscordScoreTracker/TossupBonusPhaseState.cs
+++ b/QuizBowlDiscordScoreTracker/TossupBonusPhaseState.cs
@@ -17,7 +17,7 @@ namespace QuizBowlDiscordScoreTracker
 
         private List<int> bonusScores;
 
-        public TossupBonusPhaseState() : base()
+        public TossupBonusPhaseState(bool disableBuzzQueue) : base(disableBuzzQueue)
         {
             this.bonusScores = null;
         }

--- a/QuizBowlDiscordScoreTracker/TossupOnlyPhaseState.cs
+++ b/QuizBowlDiscordScoreTracker/TossupOnlyPhaseState.cs
@@ -2,6 +2,10 @@
 {
     public class TossupOnlyPhaseState : PhaseState
     {
+        public TossupOnlyPhaseState(bool buzzQueueDisabled) : base(buzzQueueDisabled)
+        {
+        }
+
         public override PhaseStage CurrentStage => this.Actions.TryPeek(out ScoreAction result) && result.Score > 0 ?
                     PhaseStage.Complete :
                     PhaseStage.Tossup;

--- a/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
@@ -62,7 +62,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
-        public async Task DisableBonusesAlways()
+        public async Task DisableBonusesByDefault()
         {
             this.InitializeHandler();
 
@@ -75,7 +75,9 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             await this.Handler.GetDefaultFormatAsync();
             Assert.AreEqual(
-                1, this.MessageStore.ChannelEmbeds.Count, "Unexpected number of messages after getting the team role");
+                1,
+                this.MessageStore.ChannelEmbeds.Count,
+                "Unexpected number of messages after getting the default format");
             string getEmbed = this.MessageStore.ChannelEmbeds[0];
             Assert.IsTrue(
                 getEmbed.Contains("Require scoring bonuses?: Yes", StringComparison.InvariantCulture),
@@ -84,7 +86,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             await this.Handler.DisableBonusesByDefaultAsync();
             Assert.AreEqual(
-                1, this.MessageStore.ChannelMessages.Count, "Unexpected number of messages after setting the team role");
+                1, this.MessageStore.ChannelMessages.Count, "Unexpected number of messages after disabling bonuses");
             string setMessage = this.MessageStore.ChannelMessages[0];
             Assert.AreEqual(
                 "Scoring bonuses will no longer be enabled for every game in this server.",
@@ -95,7 +97,9 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             await this.Handler.GetDefaultFormatAsync();
             Assert.AreEqual(
-                1, this.MessageStore.ChannelEmbeds.Count, "Unexpected number of messages after getting the team role");
+                1,
+                this.MessageStore.ChannelEmbeds.Count,
+                "Unexpected number of messages after getting the default format after disabling bonuses");
             getEmbed = this.MessageStore.ChannelEmbeds[0];
             Assert.IsTrue(
                 getEmbed.Contains("Require scoring bonuses?: No", StringComparison.InvariantCulture),
@@ -108,7 +112,9 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             this.InitializeHandler();
             await this.Handler.EnableBonusesByDefaultAsync();
             Assert.AreEqual(
-                1, this.MessageStore.ChannelMessages.Count, "Unexpected number of messages after setting the team role");
+                1,
+                this.MessageStore.ChannelMessages.Count,
+                "Unexpected number of messages after getting the default format");
             string setMessage = this.MessageStore.ChannelMessages[0];
             Assert.AreEqual(
                 "Scoring bonuses is now enabled for every game in this server.",
@@ -119,11 +125,80 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             await this.Handler.GetDefaultFormatAsync();
             Assert.AreEqual(
-                1, this.MessageStore.ChannelEmbeds.Count, "Unexpected number of messages after getting the team role");
+                1,
+                this.MessageStore.ChannelEmbeds.Count,
+                "Unexpected number of messages after getting the default format after enabling bonuses");
             string getEmbed = this.MessageStore.ChannelEmbeds[0];
             Assert.IsTrue(
                 getEmbed.Contains("Require scoring bonuses?: Yes", StringComparison.InvariantCulture),
                 $"Enabled setting not in message \"{getEmbed}\"");
+        }
+
+        [TestMethod]
+        public async Task EnableBuzzQueue()
+        {
+            this.InitializeHandler();
+
+            // Enable, then disable the buzz queue
+            using (BotConfigurationContext context = this.botConfigurationfactory.Create())
+            using (DatabaseAction action = new DatabaseAction(context))
+            {
+                await action.SetDisableBuzzQueueAsync(DefaultGuildId, true);
+            }
+
+            await this.Handler.GetDefaultFormatAsync();
+            Assert.AreEqual(
+                1,
+                this.MessageStore.ChannelEmbeds.Count,
+                "Unexpected number of messages after getting the default format");
+            string getEmbed = this.MessageStore.ChannelEmbeds[0];
+            Assert.IsTrue(
+                getEmbed.Contains("Queue buzzes?: No", StringComparison.InvariantCulture),
+                $"Disabled setting not in message \"{getEmbed}\"");
+            this.MessageStore.Clear();
+
+            await this.Handler.EnableBuzzQueueAsync();
+            Assert.AreEqual(
+                1,
+                this.MessageStore.ChannelMessages.Count,
+                "Unexpected number of messages after disabling the buzz queue");
+            string setMessage = this.MessageStore.ChannelMessages[0];
+            Assert.IsTrue(
+                setMessage.StartsWith("The buzz queue is enabled for future games.", StringComparison.InvariantCulture),
+                $@"Couldn't find correct prefix in message ""{setMessage}""");
+
+            this.MessageStore.Clear();
+
+            await this.Handler.GetDefaultFormatAsync();
+            Assert.AreEqual(
+                1, this.MessageStore.ChannelEmbeds.Count, "Unexpected number of messages after enabling the buzz queue");
+            getEmbed = this.MessageStore.ChannelEmbeds[0];
+            Assert.IsTrue(
+                getEmbed.Contains("Queue buzzes?: Yes", StringComparison.InvariantCulture),
+                $"Enabled setting not in message \"{getEmbed}\"");
+        }
+
+        [TestMethod]
+        public async Task DisableBuzzQueue()
+        {
+            this.InitializeHandler();
+            await this.Handler.DisableBuzzQueueAsync();
+            Assert.AreEqual(
+                1, this.MessageStore.ChannelMessages.Count, "Unexpected number of messages after disabling the buzz queue");
+            string setMessage = this.MessageStore.ChannelMessages[0];
+            Assert.IsTrue(
+                setMessage.StartsWith("The buzz queue is disabled for future games.", StringComparison.InvariantCulture),
+                $@"Couldn't find correct prefix in message ""{setMessage}""");
+
+            this.MessageStore.Clear();
+
+            await this.Handler.GetDefaultFormatAsync();
+            Assert.AreEqual(
+                1, this.MessageStore.ChannelEmbeds.Count, "Unexpected number of messages after getting the default format");
+            string getEmbed = this.MessageStore.ChannelEmbeds[0];
+            Assert.IsTrue(
+                getEmbed.Contains("Queue buzzes?: No", StringComparison.InvariantCulture),
+                $"Setting not in message \"{getEmbed}\"");
         }
 
         [TestMethod]

--- a/QuizBowlDiscordScoreTrackerUnitTests/CommandMocks.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/CommandMocks.cs
@@ -219,26 +219,49 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 .Setup(channel => channel.Id)
                 .Returns(messageChannelId);
             mockMessageChannel
-                .Setup(channel => channel.SendMessageAsync(It.IsAny<string>(), false, null, It.IsAny<RequestOptions>()))
-                .Returns<string, bool, Embed, RequestOptions>((message, isTTS, embed, options) =>
-                {
-                    messageStore.ChannelMessages.Add(message);
-                    return Task.FromResult(mockUserMessage.Object);
-                });
+                .Setup(channel => channel.SendMessageAsync(
+                    It.IsAny<string>(),
+                    false,
+                    null,
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<AllowedMentions>(),
+                    It.IsAny<MessageReference>()))
+                .Returns<string, bool, Embed, RequestOptions, AllowedMentions, MessageReference>(
+                    (message, isTTS, embed, options, allowedMentions, messageReference) =>
+                    {
+                        messageStore.ChannelMessages.Add(message);
+                        return Task.FromResult(mockUserMessage.Object);
+                    });
             mockMessageChannel
-                .Setup(channel => channel.SendMessageAsync(null, false, It.IsAny<Embed>(), It.IsAny<RequestOptions>()))
-                .Returns<string, bool, Embed, RequestOptions>((message, isTTS, embed, options) =>
-                {
-                    messageStore.ChannelEmbeds.Add(GetMockEmbedText(embed));
-                    return Task.FromResult(mockUserMessage.Object);
-                });
+                .Setup(channel => channel.SendMessageAsync(
+                    null,
+                    false,
+                    It.IsAny<Embed>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<AllowedMentions>(),
+                    It.IsAny<MessageReference>()))
+                .Returns<string, bool, Embed, RequestOptions, AllowedMentions, MessageReference>(
+                    (message, isTTS, embed, options, allowedMentions, messageReference) =>
+                    {
+                        messageStore.ChannelEmbeds.Add(GetMockEmbedText(embed));
+                        return Task.FromResult(mockUserMessage.Object);
+                    });
             mockMessageChannel
                 .Setup(channel => channel.Name)
                 .Returns("gameChannel");
             mockMessageChannel
-                .Setup(channel => channel.SendFileAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<Embed>(), It.IsAny<RequestOptions>(), It.IsAny<bool>()))
-                .Returns<Stream, string, string, bool, Embed, RequestOptions, bool>(
-                    (stream, filename, text, isTTS, embed, requestOptions, isSpoiler) =>
+                .Setup(channel => channel.SendFileAsync(
+                    It.IsAny<Stream>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<Embed>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<AllowedMentions>(),
+                    It.IsAny<MessageReference>()))
+                .Returns<Stream, string, string, bool, Embed, RequestOptions, bool, AllowedMentions, MessageReference>(
+                    (stream, filename, text, isTTS, embed, requestOptions, isSpoiler, allowedMentions, messageReference) =>
                     {
                         messageStore.Files.Add((stream, filename, text));
                         return Task.FromResult(mockUserMessage.Object);

--- a/QuizBowlDiscordScoreTrackerUnitTests/ExcelFileScoresheetGeneratorTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/ExcelFileScoresheetGeneratorTests.cs
@@ -25,7 +25,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             ByCommandTeamManager teamManager = new ByCommandTeamManager();
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = teamManager
             };
@@ -88,7 +88,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             ByCommandTeamManager teamManager = new ByCommandTeamManager();
             GameState game = new GameState()
             {
-                Format = Format.TossupShootout,
+                Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
                 TeamManager = teamManager
             };
@@ -140,7 +140,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             ByCommandTeamManager teamManager = new ByCommandTeamManager();
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = teamManager
             };
@@ -191,7 +191,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             ByCommandTeamManager teamManager = new ByCommandTeamManager();
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = teamManager
             };
@@ -242,7 +242,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             ByCommandTeamManager teamManager = new ByCommandTeamManager();
             GameState game = new GameState()
             {
-                Format = Format.TossupShootout,
+                Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
                 TeamManager = teamManager
             };
@@ -281,7 +281,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             ByCommandTeamManager teamManager = new ByCommandTeamManager();
             GameState game = new GameState()
             {
-                Format = Format.TossupShootout,
+                Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
                 TeamManager = teamManager
             };
@@ -315,7 +315,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             ByCommandTeamManager teamManager = new ByCommandTeamManager();
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = teamManager
             };
@@ -338,7 +338,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             ByCommandTeamManager teamManager = new ByCommandTeamManager();
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = teamManager
             };

--- a/QuizBowlDiscordScoreTrackerUnitTests/GameStateTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/GameStateTests.cs
@@ -239,7 +239,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             GameState gameState = new GameState
             {
                 ReaderId = readerId,
-                Format = Format.TossupBonusesShootout
+                Format = Format.CreateTossupBonusesShootout(false)
             };
 
             Assert.AreEqual(PhaseStage.Tossup, gameState.CurrentStage, "Unexpected initial stage");
@@ -250,7 +250,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             Assert.AreEqual(PhaseStage.Tossup, gameState.CurrentStage, "Unexpected stage after scoring the bonus");
             Assert.AreEqual(2, gameState.PhaseNumber, "Unexpected phase number after scoring the bonus");
-            gameState.Format = Format.TossupShootout;
+            gameState.Format = Format.CreateTossupShootout(false);
             Assert.IsTrue(await gameState.AddPlayer(id, "Player"), "Second add should succeed.");
             gameState.ScorePlayer(10);
 
@@ -291,7 +291,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             GameState gameState = new GameState
             {
                 ReaderId = readerId,
-                Format = Format.TossupBonusesShootout
+                Format = Format.CreateTossupBonusesShootout(false)
             };
 
             Assert.AreEqual(PhaseStage.Tossup, gameState.CurrentStage, "Unexpected initial stage");
@@ -313,7 +313,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             GameState gameState = new GameState
             {
                 ReaderId = readerId,
-                Format = Format.TossupBonusesShootout
+                Format = Format.CreateTossupBonusesShootout(false)
             };
 
             Assert.AreEqual(PhaseStage.Tossup, gameState.CurrentStage, "Unexpected initial stage");
@@ -568,7 +568,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             GameState gameState = new GameState
             {
-                Format = Format.TossupBonusesShootout
+                Format = Format.CreateTossupBonusesShootout(false)
             };
             Assert.IsTrue(await gameState.AddPlayer(firstId, "Player1"), "First add should succeed.");
 
@@ -753,7 +753,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             GameState gameState = new GameState()
             {
-                Format = Format.TossupBonusesShootout
+                Format = Format.CreateTossupBonusesShootout(false)
             };
 
             Assert.IsTrue(await gameState.AddPlayer(firstId, "Player1"), "First add should succeed.");

--- a/QuizBowlDiscordScoreTrackerUnitTests/GeneralCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/GeneralCommandHandlerTests.cs
@@ -341,7 +341,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             ulong buzzer = GetExistingNonReaderUserId();
             this.InitializeHandler();
             this.Game.ReaderId = 0;
-            this.Game.Format = Format.TossupBonusesShootout;
+            this.Game.Format = Format.CreateTossupBonusesShootout(false);
 
             await this.Game.AddPlayer(buzzer, playerName);
             this.Game.ScorePlayer(10);
@@ -371,7 +371,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             ulong buzzer = GetExistingNonReaderUserId();
             this.InitializeHandler();
             this.Game.ReaderId = 0;
-            this.Game.Format = Format.TossupBonusesShootout;
+            this.Game.Format = Format.CreateTossupBonusesShootout(false);
 
             await this.Game.AddPlayer(buzzer, playerName);
             this.Game.ScorePlayer(10);
@@ -680,7 +680,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             ulong[] players = Enumerable.Range(firstId, playersCount).Select(id => (ulong)id).ToArray();
             this.InitializeHandler();
             this.Game.ReaderId = 0;
-            this.Game.Format = Format.TossupBonusesShootout;
+            this.Game.Format = Format.CreateTossupBonusesShootout(false);
 
             // All tied for 1st
             for (int i = 0; i < 3; i++)
@@ -1297,7 +1297,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             this.InitializeHandler();
             this.Game.ReaderId = DefaultReaderId;
             this.Game.TeamManager = new SoloOnlyTeamManager();
-            this.Game.Format = Format.TossupBonusesShootout;
+            this.Game.Format = Format.CreateTossupBonusesShootout(false);
 
             await this.Game.AddPlayer(1, firstPlayerName);
             this.Game.ScorePlayer(10);
@@ -1366,7 +1366,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                         });
                 });
             this.Game.ReaderId = DefaultReaderId;
-            this.Game.Format = Format.TossupBonusesShootout;
+            this.Game.Format = Format.CreateTossupBonusesShootout(false);
 
             await this.Game.AddPlayer(1, playerName);
             this.Game.ScorePlayer(10);

--- a/QuizBowlDiscordScoreTrackerUnitTests/MessageHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/MessageHandlerTests.cs
@@ -225,7 +225,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 out IGuildUser readerUser,
                 out IGuildTextChannel channel,
                 out MessageStore messageStore);
-            state.Format = Format.TossupBonusesShootout;
+            state.Format = Format.CreateTossupBonusesShootout(false);
 
             await handler.HandlePlayerMessage(state, playerUser, channel, BotId, "buzz");
             messageStore.VerifyChannelMessages(playerUser.Mention);

--- a/QuizBowlDiscordScoreTrackerUnitTests/QuizBowlDiscordScoreTrackerUnitTests.csproj
+++ b/QuizBowlDiscordScoreTrackerUnitTests/QuizBowlDiscordScoreTrackerUnitTests.csproj
@@ -13,10 +13,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="Discord.Net" Version="2.2.0" />
+    <PackageReference Include="Discord.Net" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/QuizBowlDiscordScoreTrackerUnitTests/QuizBowlDiscordScoreTrackerUnitTests.csproj
+++ b/QuizBowlDiscordScoreTrackerUnitTests/QuizBowlDiscordScoreTrackerUnitTests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.95.3" />
+    <PackageReference Include="ClosedXML" Version="0.95.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />

--- a/QuizBowlDiscordScoreTrackerUnitTests/ReaderCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/ReaderCommandHandlerTests.cs
@@ -223,7 +223,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             ulong buzzer = GetExistingNonReaderUserId();
             this.InitializeHandler();
-            this.Game.Format = Format.TossupBonusesShootout;
+            this.Game.Format = Format.CreateTossupBonusesShootout(false);
 
             this.Game.ReaderId = DefaultReaderId;
             await this.Game.AddPlayer(buzzer, "Player");
@@ -244,7 +244,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             ulong buzzer = GetExistingNonReaderUserId();
             this.InitializeHandler();
-            this.Game.Format = Format.TossupBonusesShootout;
+            this.Game.Format = Format.CreateTossupBonusesShootout(false);
 
             this.Game.ReaderId = DefaultReaderId;
             await this.Game.AddPlayer(buzzer, "Player");
@@ -265,7 +265,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             ulong buzzer = GetExistingNonReaderUserId();
             this.InitializeHandler();
-            this.Game.Format = Format.TossupBonusesShootout;
+            this.Game.Format = Format.CreateTossupBonusesShootout(false);
 
             this.Game.ReaderId = DefaultReaderId;
             this.Game.NextQuestion();
@@ -429,7 +429,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             ulong buzzer = GetExistingNonReaderUserId();
             this.InitializeHandler();
-            this.Game.Format = Format.TossupBonusesShootout;
+            this.Game.Format = Format.CreateTossupBonusesShootout(false);
 
             this.Game.ReaderId = DefaultReaderId;
             await this.Game.AddPlayer(buzzer, "Player");
@@ -444,7 +444,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             ulong buzzer = GetExistingNonReaderUserId();
             this.InitializeHandler();
-            this.Game.Format = Format.TossupBonusesShootout;
+            this.Game.Format = Format.CreateTossupBonusesShootout(false);
 
             Assert.IsTrue(await this.Game.AddPlayer(buzzer, "Player"), "Should've been able to add the player");
 
@@ -455,7 +455,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 "Bonuses are no longer being tracked. Scores for the current question have been cleared.",
                 message,
                 $"Unexpected message");
-            Assert.AreEqual(Format.TossupShootout, this.Game.Format, "Unexpected format");
+            Assert.AreEqual(Format.CreateTossupShootout(false), this.Game.Format, "Unexpected format");
             Assert.IsTrue(await this.Game.AddPlayer(buzzer, "Player"), "Should've been able to add the player again");
         }
 
@@ -463,7 +463,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         public async Task DisableBonusesSucceedsIfEnableBonusSetByDefault()
         {
             this.InitializeHandler();
-            this.Game.Format = Format.TossupBonusesShootout;
+            this.Game.Format = Format.CreateTossupBonusesShootout(false);
 
             using (BotConfigurationContext context = this.botConfigurationfactory.Create())
             using (DatabaseAction action = new DatabaseAction(context))
@@ -478,7 +478,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 "Bonuses are no longer being tracked for this game only. Run !disableBonusesByDefault to stop tracking bonuses on this server by default.\nScores for the current question have been cleared.",
                 message,
                 $"Unexpected message");
-            Assert.AreEqual(Format.TossupShootout, this.Game.Format, "Unexpected format");
+            Assert.AreEqual(Format.CreateTossupShootout(false), this.Game.Format, "Unexpected format");
         }
 
         [TestMethod]
@@ -486,7 +486,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             ulong buzzer = GetExistingNonReaderUserId();
             this.InitializeHandler();
-            this.Game.Format = Format.TossupShootout;
+            this.Game.Format = Format.CreateTossupShootout(false);
 
             Assert.IsTrue(await this.Game.AddPlayer(buzzer, "Player"), "Should've been able to add the player");
 
@@ -497,7 +497,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 "Bonuses are already untracked.",
                 message,
                 $"Unexpected message");
-            Assert.AreEqual(Format.TossupShootout, this.Game.Format, "Unexpected format");
+            Assert.AreEqual(Format.CreateTossupShootout(false), this.Game.Format, "Unexpected format");
             Assert.IsFalse(await this.Game.AddPlayer(buzzer, "Player"), "Shouldn't be able to add the player again");
         }
 
@@ -506,7 +506,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             ulong buzzer = GetExistingNonReaderUserId();
             this.InitializeHandler();
-            this.Game.Format = Format.TossupShootout;
+            this.Game.Format = Format.CreateTossupShootout(false);
 
             Assert.IsTrue(await this.Game.AddPlayer(buzzer, "Player"), "Should've been able to add the player");
 
@@ -517,7 +517,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 "Bonuses are now being tracked. Scores for the current question have been cleared.",
                 message,
                 $"Unexpected message");
-            Assert.AreEqual(Format.TossupBonusesShootout, this.Game.Format, "Unexpected format");
+            Assert.AreEqual(Format.CreateTossupBonusesShootout(false), this.Game.Format, "Unexpected format");
             Assert.IsTrue(await this.Game.AddPlayer(buzzer, "Player"), "Should've been able to add the player again");
         }
 
@@ -526,7 +526,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             ulong buzzer = GetExistingNonReaderUserId();
             this.InitializeHandler();
-            this.Game.Format = Format.TossupBonusesShootout;
+            this.Game.Format = Format.CreateTossupBonusesShootout(false);
 
             Assert.IsTrue(await this.Game.AddPlayer(buzzer, "Player"), "Should've been able to add the player");
 
@@ -537,7 +537,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 "Bonuses are already tracked.",
                 message,
                 $"Unexpected message");
-            Assert.AreEqual(Format.TossupBonusesShootout, this.Game.Format, "Unexpected format");
+            Assert.AreEqual(Format.CreateTossupBonusesShootout(false), this.Game.Format, "Unexpected format");
             Assert.IsFalse(await this.Game.AddPlayer(buzzer, "Player"), "Shouldn't be able to add the player again");
         }
 

--- a/QuizBowlDiscordScoreTrackerUnitTests/TJSheetsGeneratorTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/TJSheetsGeneratorTests.cs
@@ -116,7 +116,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             // Do something simple, then read the spreadsheet and verify some fields
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -190,7 +190,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             // Do something simple, then read the spreadsheet and verify some fields
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -237,7 +237,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             // Do something simple, then read the spreadsheet and verify some fields
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -280,7 +280,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupShootout,
+                Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -323,7 +323,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -358,7 +358,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -401,7 +401,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupShootout,
+                Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -446,7 +446,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             GameState game = new GameState()
             {
-                Format = Format.TossupShootout,
+                Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -477,7 +477,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupShootout,
+                Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -498,7 +498,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             game.ScorePlayer(15);
 
             result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
-            Assert.IsTrue(result.Success, $"Creation should've succeeded.");            
+            Assert.IsTrue(result.Success, $"Creation should've succeeded.");
             this.AssertInUpdateRange($"'ROUND 1'!C27", "10", "Couldn't find the last buzz");
             Assert.IsFalse(
                 this.UpdatedRanges
@@ -511,7 +511,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -532,7 +532,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };

--- a/QuizBowlDiscordScoreTrackerUnitTests/UCSDGoogleSheetsGeneratorTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/UCSDGoogleSheetsGeneratorTests.cs
@@ -106,7 +106,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             // Do something simple, then read the spreadsheet and verify some fields
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -179,7 +179,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupShootout,
+                Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -222,7 +222,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -257,7 +257,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -300,7 +300,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupShootout,
+                Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -345,7 +345,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             GameState game = new GameState()
             {
-                Format = Format.TossupShootout,
+                Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -376,7 +376,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupShootout,
+                Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -410,7 +410,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };
@@ -431,7 +431,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             GameState game = new GameState()
             {
-                Format = Format.TossupBonusesShootout,
+                Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
                 TeamManager = this.TeamManager
             };


### PR DESCRIPTION
- Fix issue where team names could get placed in the wrong column when exporting a file scoresheet (#82)
- Add new server setting to disable the buzz queue, so only one buzz is recognized. Players whose buzz wasn't recognized must buzz in later after the reader judges the answer.
    - Added commands to set this setting (!enableBuzzQueue, !disableBuzzQueue)
- Upgrade various libraries to the latest version (Discord.Net, EF Core, Serilog, Moq)