### PR TITLE
Merged PR 160: v3.8.1 - Bugfix for teams appearing in games when they had no permissions to it

### DIFF
--- a/QuizBowlDiscordScoreTracker/Commands/AdminCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/AdminCommandHandler.cs
@@ -356,6 +356,11 @@ namespace QuizBowlDiscordScoreTracker.Commands
             Justification = "Discord.Net can't parse the argument directly as a URI")]
         private async Task SetRostersFromRolesForSheets(string sheetsUrl, GoogleSheetsType type)
         {
+            if (!(this.Context.Channel is IGuildChannel guildChannel))
+            {
+                return;
+            }
+
             if (!Uri.TryCreate(sheetsUrl, UriKind.Absolute, out Uri sheetsUri))
             {
                 await this.Context.Channel.SendMessageAsync(
@@ -379,7 +384,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
                 return;
             }
 
-            ITeamManager teamManager = new ByRoleTeamManager(this.Context.Guild, teamRolePrefix);
+            ITeamManager teamManager = new ByRoleTeamManager(guildChannel, teamRolePrefix);
             IGoogleSheetsGenerator generator = this.GoogleSheetsGeneratorFactory.Create(type);
             IResult<string> result = await generator.TryUpdateRosters(teamManager, sheetsUri);
 

--- a/QuizBowlDiscordScoreTracker/Commands/GeneralCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/GeneralCommandHandler.cs
@@ -244,6 +244,10 @@ namespace QuizBowlDiscordScoreTracker.Commands
                 Logger.Information(
                      "Game started in guild '{0}' in channel '{1}'", guildChannel.Guild.Name, guildChannel.Name);
             }
+            else
+            {
+                return;
+            }
 
             // Prevent a cold start on the first buzz, and eagerly get the team prefix and channel pair
             string teamRolePrefix;
@@ -264,7 +268,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
             // Set teams here, if they are using roles.
             if (teamRolePrefix != null)
             {
-                state.TeamManager = new ByRoleTeamManager(this.Context.Guild, teamRolePrefix);
+                state.TeamManager = new ByRoleTeamManager(guildChannel, teamRolePrefix);
             }
             else
             {

--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.8.0</Version>
+    <Version>3.8.1</Version>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Company />
     <Product>Quiz Bowl Discord Score Tracker</Product>

--- a/QuizBowlDiscordScoreTrackerUnitTests/GeneralCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/GeneralCommandHandlerTests.cs
@@ -1695,12 +1695,24 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
             // TODO: Need to update the Mock User to specify RoleIds
             // And this needs to come from GetUserId
             ITeamManager teamManager = null;
-            teamManager = teamManagerType switch
+            switch (teamManagerType)
             {
-                TeamManagerType.ByCommand => new ByCommandTeamManager(),
-                TeamManagerType.ByRole => new ByRoleTeamManager(commandContext.Guild, "Team "),
-                _ => SoloOnlyTeamManager.Instance,
-            };
+                case TeamManagerType.ByCommand:
+                    teamManager = new ByCommandTeamManager();
+                    break;
+                case TeamManagerType.ByRole:
+                    Mock<IGuildChannel> mockGuildChannel = new Mock<IGuildChannel>();
+                    mockGuildChannel
+                        .SetupGet(channel => channel.Guild)
+                        .Returns(commandContext.Guild);
+
+                    teamManager = new ByRoleTeamManager(mockGuildChannel.Object, "Team ");
+                    break;
+                default:
+                    teamManager = SoloOnlyTeamManager.Instance;
+                    break;
+            }
+
             game.TeamManager = teamManager;
 
             this.Game = game;


### PR DESCRIPTION
- Fix a bug where roles without view/send permissions to a channel were always included in games when the server set teams by the role prefix
- Bump version to 3.8.1