### PR TITLE
Merged PR 177: Fix bug where team roles were ignored by !setRosters i…

### DIFF
--- a/QuizBowlDiscordScoreTracker/Commands/AdminCommandHandler.cs
+++ b/QuizBowlDiscordScoreTracker/Commands/AdminCommandHandler.cs
@@ -352,8 +352,6 @@ namespace QuizBowlDiscordScoreTracker.Commands
             await this.Context.Channel.SendMessageAsync("Text and voice channel unpaired successfully");
         }
 
-        [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings",
-            Justification = "Discord.Net can't parse the argument directly as a URI")]
         private async Task SetRostersFromRolesForSheets(string sheetsUrl, GoogleSheetsType type)
         {
             if (!(this.Context.Channel is IGuildChannel guildChannel))
@@ -384,7 +382,7 @@ namespace QuizBowlDiscordScoreTracker.Commands
                 return;
             }
 
-            ITeamManager teamManager = new ByRoleTeamManager(guildChannel, teamRolePrefix);
+            IByRoleTeamManager teamManager = new ByRoleTeamManager(guildChannel, teamRolePrefix);
             IGoogleSheetsGenerator generator = this.GoogleSheetsGeneratorFactory.Create(type);
             IResult<string> result = await generator.TryUpdateRosters(teamManager, sheetsUri);
 

--- a/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
+++ b/QuizBowlDiscordScoreTracker/QuizBowlDiscordScoreTracker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.8.1</Version>
+    <Version>3.8.2</Version>
     <Authors>Alejandro Lopez-Lago</Authors>
     <Company />
     <Product>Quiz Bowl Discord Score Tracker</Product>

--- a/QuizBowlDiscordScoreTracker/Scoresheet/IGoogleSheetsGenerator.cs
+++ b/QuizBowlDiscordScoreTracker/Scoresheet/IGoogleSheetsGenerator.cs
@@ -32,6 +32,6 @@ namespace QuizBowlDiscordScoreTracker.Scoresheet
         /// <param name="teamManager">Team Manager used in the server or game.</param>
         /// <param name="sheetsUri">URI to the Google Sheet with the worksheet for the tournament's rosters</param>
         /// <returns>A result with an error code if the update failed, or a result with an empty string on success</returns>
-        Task<IResult<string>> TryUpdateRosters(ITeamManager teamManager, Uri sheetsUri);
+        Task<IResult<string>> TryUpdateRosters(IByRoleTeamManager teamManager, Uri sheetsUri);
     }
 }

--- a/QuizBowlDiscordScoreTracker/TeamManager/IByRoleTeamManager.cs
+++ b/QuizBowlDiscordScoreTracker/TeamManager/IByRoleTeamManager.cs
@@ -1,16 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace QuizBowlDiscordScoreTracker.TeamManager
 {
-    public interface IByRoleTeamManager
+    public interface IByRoleTeamManager : ITeamManager
     {
+        Task<IReadOnlyDictionary<string, string>> GetTeamIdToNamesForServer();
+
         /// <summary>
         /// Reloads teams from the roles
         /// </summary>
         /// <returns>Returns the message to report after the roles were reloaded</returns>
         string ReloadTeamRoles();
+
+        /// <summary>
+        /// Gets a grouping of every player to their team in the server. This will ignore channel permissions for
+        /// learning who is on a team
+        /// </summary>
+        /// <returns>A grouping of team names to PlayerTeamPairs for every team in the server.</returns>
+        Task<IEnumerable<IGrouping<string, PlayerTeamPair>>> GetPlayerTeamPairsForServer();
     }
 }

--- a/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/AdminCommandHandlerTests.cs
@@ -493,7 +493,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             Mock<IGoogleSheetsGenerator> mockGenerator = new Mock<IGoogleSheetsGenerator>();
             mockGenerator
-                .Setup(generator => generator.TryUpdateRosters(It.IsAny<ITeamManager>(), It.IsAny<Uri>()))
+                .Setup(generator => generator.TryUpdateRosters(It.IsAny<IByRoleTeamManager>(), It.IsAny<Uri>()))
                 .Returns(Task.FromResult<IResult<string>>(new FailureResult<string>(errorMessage)))
                 .Verifiable();
 
@@ -521,7 +521,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             Mock<IGoogleSheetsGenerator> mockGenerator = new Mock<IGoogleSheetsGenerator>();
             mockGenerator
-                .Setup(generator => generator.TryUpdateRosters(It.IsAny<ITeamManager>(), It.IsAny<Uri>()))
+                .Setup(generator => generator.TryUpdateRosters(It.IsAny<IByRoleTeamManager>(), It.IsAny<Uri>()))
                 .Returns(Task.FromResult<IResult<string>>(new SuccessResult<string>(string.Empty)))
                 .Verifiable();
 
@@ -549,7 +549,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             Mock<IGoogleSheetsGenerator> mockGenerator = new Mock<IGoogleSheetsGenerator>();
             mockGenerator
-                .Setup(generator => generator.TryUpdateRosters(It.IsAny<ITeamManager>(), It.IsAny<Uri>()))
+                .Setup(generator => generator.TryUpdateRosters(It.IsAny<IByRoleTeamManager>(), It.IsAny<Uri>()))
                 .Returns(Task.FromResult<IResult<string>>(new SuccessResult<string>(string.Empty)))
                 .Verifiable();
 
@@ -572,7 +572,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         {
             Mock<IGoogleSheetsGenerator> mockGenerator = new Mock<IGoogleSheetsGenerator>();
             mockGenerator
-                .Setup(generator => generator.TryUpdateRosters(It.IsAny<ITeamManager>(), It.IsAny<Uri>()))
+                .Setup(generator => generator.TryUpdateRosters(It.IsAny<IByRoleTeamManager>(), It.IsAny<Uri>()))
                 .Returns(Task.FromResult<IResult<string>>(new SuccessResult<string>(string.Empty)));
 
             Mock<IGoogleSheetsGeneratorFactory> mockFactory = new Mock<IGoogleSheetsGeneratorFactory>();

--- a/QuizBowlDiscordScoreTrackerUnitTests/BaseGoogleSheetsGeneratorTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/BaseGoogleSheetsGeneratorTests.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using Google.Apis.Sheets.v4.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using QuizBowlDiscordScoreTracker;
+using QuizBowlDiscordScoreTracker.Scoresheet;
+using QuizBowlDiscordScoreTracker.TeamManager;
+
+namespace QuizBowlDiscordScoreTrackerUnitTests
+{
+    public abstract class BaseGoogleSheetsGeneratorTests
+    {
+        protected static readonly Uri SheetsUri = new Uri("http://localhost/sheets/sheetsId/");
+
+        protected const string FirstTeam = "Alpha";
+        protected const string SecondTeam = "Beta";
+
+        protected List<string> ClearedRanges { get; private set; }
+
+        protected BaseGoogleSheetsGenerator Generator { get; set; }
+
+        protected List<UpdateRange> UpdatedRanges { get; private set; }
+
+        [TestInitialize]
+        public void InitializeTest()
+        {
+            // Clear out the old fields
+            this.UpdatedRanges = new List<UpdateRange>();
+            this.ClearedRanges = new List<string>();
+
+            IGoogleSheetsApi googleSheetsApi = this.CreateGoogleSheetsApi();
+            this.Generator = this.CreateGenerator(googleSheetsApi);
+        }
+
+        [TestMethod]
+        public async Task SetRostersFailsWithTooManyPlayers()
+        {
+            List<PlayerTeamPair> players = new List<PlayerTeamPair>();
+            for (int i = 0; i < this.Generator.PlayersPerTeamLimit; i++)
+            {
+                players.Add(new PlayerTeamPair((ulong)i, $"{i}", FirstTeam));
+            }
+
+            IByRoleTeamManager teamManager = CreateTeamManager(players.ToArray());
+
+            IResult<string> result = await this.Generator.TryUpdateRosters(teamManager, SheetsUri);
+            Assert.IsTrue(result.Success, $"Update should've succeeded at the limit.");
+
+            players.Add(new PlayerTeamPair(1111, "OverLimit", FirstTeam));
+            teamManager = CreateTeamManager(players.ToArray());
+
+            result = await this.Generator.TryUpdateRosters(teamManager, SheetsUri);
+            Assert.IsFalse(result.Success, $"Update should've failed after the limit.");
+            Assert.AreEqual(
+                $"Couldn't write to the sheet. Rosters can only support up to {this.Generator.PlayersPerTeamLimit} players per team.",
+                result.ErrorMessage,
+                "Unexpected error message");
+        }
+
+        [TestMethod]
+        public async Task TryCreateScoresheetPastPlayerLimitFails()
+        {
+            List<PlayerTeamPair> players = new List<PlayerTeamPair>();
+            for (int i = 0; i < this.Generator.PlayersPerTeamLimit; i++)
+            {
+                players.Add(new PlayerTeamPair((ulong)i + 2, $"Player{i}", FirstTeam));
+                players.Add(new PlayerTeamPair((ulong)i + 200, $"Player{i}", SecondTeam));
+            }
+
+            IByRoleTeamManager teamManager = CreateTeamManager(players.ToArray());
+
+            GameState game = new GameState()
+            {
+                Format = Format.CreateTossupShootout(false),
+                ReaderId = 1,
+                TeamManager = teamManager
+            };
+
+            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
+            Assert.IsTrue(result.Success, $"Creation should've succeeded at the limit.");
+
+            players.Add(new PlayerTeamPair(1111, "OverLimit", FirstTeam));
+            teamManager = CreateTeamManager(players.ToArray());
+            game.TeamManager = teamManager;
+
+            // We need to force an update to the game, so we don't have cached stats
+            await game.AddPlayer(2, "Player2");
+            game.ScorePlayer(0);
+
+            result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
+            Assert.IsFalse(result.Success, $"Creation should've failed after the limit.");
+            Assert.AreEqual(
+                $"Couldn't write to the sheet. Export only currently works if there are at most {this.Generator.PlayersPerTeamLimit} players on a team.",
+                result.ErrorMessage,
+                "Unexpected error message");
+        }
+
+        [TestMethod]
+        public async Task TryCreateScoresheetWithoutTeamsFails()
+        {
+            IByRoleTeamManager teamManager = CreateTeamManager();
+
+            GameState game = new GameState()
+            {
+                Format = Format.CreateTossupBonusesShootout(false),
+                ReaderId = 1,
+                TeamManager = teamManager
+            };
+
+            await game.AddPlayer(2, "Alice");
+            game.ScorePlayer(10);
+
+            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
+            Assert.IsFalse(result.Success, $"Creation succeeded when it should've failed.");
+            Assert.AreEqual(
+                "Couldn't write to the sheet. Export only works if there are 1 or 2 teams in the game.",
+                result.ErrorMessage,
+                "Unexpected error message");
+        }
+
+        [TestMethod]
+        public async Task TryCreateScoresheetWithMoreThanTwoTeamsFails()
+        {
+            PlayerTeamPair[] players = new PlayerTeamPair[3];
+            for (int i = 0; i < players.Length; i++)
+            {
+                players[i] = new PlayerTeamPair((ulong)i + 100, $"Player{i}", $"Team{i}");
+            }
+
+            IByRoleTeamManager teamManager = CreateTeamManager(players);
+
+            GameState game = new GameState()
+            {
+                Format = Format.CreateTossupBonusesShootout(false),
+                ReaderId = 1,
+                TeamManager = teamManager
+            };
+
+            await game.AddPlayer(2, "Alice");
+            game.ScorePlayer(10);
+
+            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
+            Assert.IsFalse(result.Success, $"Creation succeeded when it should've failed.");
+            Assert.AreEqual(
+                "Couldn't write to the sheet. Export only works if there are 1 or 2 teams in the game.",
+                result.ErrorMessage,
+                "Unexpected error message");
+        }
+
+        protected abstract BaseGoogleSheetsGenerator CreateGenerator(IGoogleSheetsApi sheetsApi);
+
+        protected static IByRoleTeamManager CreateDefaultTeamManager()
+        {
+            return CreateTeamManager(
+                new PlayerTeamPair(2, "Alice", FirstTeam),
+                new PlayerTeamPair(3, "Alan", FirstTeam),
+                new PlayerTeamPair(4, "Bob", SecondTeam));
+        }
+
+        protected static IByRoleTeamManager CreateTeamManager(params PlayerTeamPair[] playerTeamPairs)
+        {
+            IEnumerable<IGrouping<string, PlayerTeamPair>> grouping = playerTeamPairs.GroupBy(pair => pair.TeamId);
+            IReadOnlyDictionary<string, string> teamIdToNames = playerTeamPairs
+                .Select(pair => pair.TeamId)
+                .Distinct()
+                .ToDictionary(key => key);
+
+            Mock<IByRoleTeamManager> mockTeamManager = new Mock<IByRoleTeamManager>();
+            mockTeamManager
+                .Setup(manager => manager.GetTeamIdToNamesForServer())
+                .Returns(Task.FromResult(teamIdToNames));
+            mockTeamManager
+                .Setup(manager => manager.GetPlayerTeamPairsForServer())
+                .Returns(Task.FromResult(grouping));
+
+            mockTeamManager
+                .Setup(manager => manager.GetTeamIdToNames())
+                .Returns(Task.FromResult(teamIdToNames));
+            mockTeamManager
+                .Setup(manager => manager.GetKnownPlayers())
+                .Returns(Task.FromResult<IEnumerable<PlayerTeamPair>>(playerTeamPairs));
+
+            mockTeamManager
+                .Setup(manager => manager.GetTeamIdOrNull(It.IsAny<ulong>()))
+                .Returns<ulong>((userId) =>
+                {
+                    PlayerTeamPair player = playerTeamPairs.FirstOrDefault(player => player.PlayerId == userId);
+                    return Task.FromResult(
+                        player != null && teamIdToNames.TryGetValue(player.TeamId, out string teamId) ?
+                            teamId :
+                            (string)null);
+                });
+
+            return mockTeamManager.Object;
+        }
+
+        protected void AssertInUpdateRange(string range, string value, string message)
+        {
+            Assert.IsTrue(
+                this.UpdatedRanges
+                    .Any(valueRange => valueRange.Range == range && valueRange.Values.Any(v => v.ToString() == value)),
+                message);
+        }
+
+        protected IGoogleSheetsApi CreateGoogleSheetsApi()
+        {
+            Mock<IGoogleSheetsApi> mockGoogleSheetsApi = new Mock<IGoogleSheetsApi>();
+            mockGoogleSheetsApi
+                .Setup(api => api.UpdateGoogleSheet(It.IsAny<List<ValueRange>>(), It.IsAny<List<string>>(), It.IsAny<Uri>()))
+                .Returns<List<ValueRange>, List<string>, Uri>((updateRanges, clearRanges, sheetsUri) =>
+                {
+                    this.UpdatedRanges.AddRange(updateRanges.Select(range =>
+                        new UpdateRange()
+                        {
+                            Range = range.Range,
+                            Values = range.Values.Count > 0 ? range.Values[0] : new List<object>()
+                        }));
+                    this.ClearedRanges.AddRange(clearRanges);
+                    return Task.FromResult<IResult<string>>(new SuccessResult<string>(string.Empty));
+                });
+            return mockGoogleSheetsApi.Object;
+        }
+
+        protected class UpdateRange
+        {
+            public string Range { get; set; }
+
+
+            [SuppressMessage(
+                "Usage",
+                "CA2227:Collection properties should be read only",
+                Justification = "Only used to set the values in a property-initializer constructor")]
+            public IList<object> Values { get; set; }
+        }
+    }
+}

--- a/QuizBowlDiscordScoreTrackerUnitTests/ByRoleTeamManagerTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/ByRoleTeamManagerTests.cs
@@ -78,6 +78,26 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
+        public async Task GetKnownPlayersNoRolesEveryoneDeniedView()
+        {
+            ByRoleTeamManager teamManager = CreateTeamManager((roleId) => roleId != EveryoneRoleId ?
+                (OverwritePermissions?)null :
+                new OverwritePermissions(viewChannel: PermValue.Deny));
+            IEnumerable<PlayerTeamPair> pairs = await teamManager.GetKnownPlayers();
+            Assert.AreEqual(0, pairs.Count(), "Unexpected number of players");
+        }
+
+        [TestMethod]
+        public async Task GetPlayerTeamPairsForServerNoRolesEveryoneDeniedView()
+        {
+            ByRoleTeamManager teamManager = CreateTeamManager((roleId) => roleId != EveryoneRoleId ?
+                (OverwritePermissions?)null :
+                new OverwritePermissions(viewChannel: PermValue.Deny));
+            IEnumerable<IGrouping<string, PlayerTeamPair>> pairs = await teamManager.GetPlayerTeamPairsForServer();
+            Assert.AreEqual(PlayerIds.Length, pairs.Count(), "Unexpected number of players");
+        }
+
+        [TestMethod]
         public async Task GetTeamIdToNamesNoOverwritePermissions()
         {
             ByRoleTeamManager teamManager = CreateTeamManager();
@@ -270,6 +290,16 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
 
             IReadOnlyDictionary<string, string> teamIdToName = await teamManager.GetTeamIdToNames();
             VerifyOnlyOneTeamInTeamIdToName(teamIdToName, 1);
+        }
+
+        [TestMethod]
+        public async Task GetTeamIdToNamesForServerNoRolesEveryoneDeniedView()
+        {
+            ByRoleTeamManager teamManager = CreateTeamManager((roleId) => roleId != EveryoneRoleId ?
+                (OverwritePermissions?)null :
+                new OverwritePermissions(viewChannel: PermValue.Deny));
+            IReadOnlyDictionary<string, string> teamIdToName = await teamManager.GetTeamIdToNamesForServer();
+            Assert.AreEqual(2, teamIdToName.Count, "Unexpected number of teams");
         }
 
         [TestMethod]

--- a/QuizBowlDiscordScoreTrackerUnitTests/TJSheetsGeneratorTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/TJSheetsGeneratorTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Google.Apis.Sheets.v4.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using QuizBowlDiscordScoreTracker;
@@ -12,120 +10,32 @@ using QuizBowlDiscordScoreTracker.TeamManager;
 namespace QuizBowlDiscordScoreTrackerUnitTests
 {
     [TestClass]
-    public class TJheetsGeneratorTests
+    public class TJheetsGeneratorTests : BaseGoogleSheetsGeneratorTests
     {
-        private const string FirstTeam = "Alpha";
-        private const string SecondTeam = "Beta";
-
-        private static readonly Uri SheetsUri = new Uri("http://localhost/sheets/sheetsId/");
-
-        private List<string> ClearedRanges { get; set; }
-
-        private TJSheetsGenerator Generator { get; set; }
-
-        private ByCommandTeamManager TeamManager { get; set; }
-
-        private List<UpdateRange> UpdatedRanges { get; set; }
-
-        [TestInitialize]
-        public void InitializeTest()
+        protected override BaseGoogleSheetsGenerator CreateGenerator(IGoogleSheetsApi sheetsApi)
         {
-            // Clear out the old fields
-            this.UpdatedRanges = new List<UpdateRange>();
-            this.ClearedRanges = new List<string>();
-            this.TeamManager = new ByCommandTeamManager();
-
-            IGoogleSheetsApi googleSheetsApi = this.CreateGoogleSheetsApi();
-            this.Generator = new TJSheetsGenerator(googleSheetsApi);
+            return new TJSheetsGenerator(sheetsApi);
         }
 
         [TestMethod]
         public async Task SetRostersSucceeds()
         {
-            this.TeamManager.TryAddTeam(FirstTeam, out _);
-            this.TeamManager.TryAddTeam(SecondTeam, out _);
-            this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam);
-            this.TeamManager.TryAddPlayerToTeam(3, "Alan", FirstTeam);
-            this.TeamManager.TryAddPlayerToTeam(4, "Bob", SecondTeam);
-
-            IResult<string> result = await this.Generator.TryUpdateRosters(this.TeamManager, SheetsUri);
-            Assert.IsTrue(result.Success, "Update should've succeeded");
-
-            Assert.AreEqual(1, this.ClearedRanges.Count, "Unexpected number of clears");
-            Assert.AreEqual($"'{TJSheetsGenerator.RostersSheetName}'!A1:ZZ21", this.ClearedRanges[0], "Unexpected range");
-
-            Assert.AreEqual(3, this.UpdatedRanges.Count, "Unexpected number of update ranges");
-
-            UpdateRange updateRange = this.UpdatedRanges[0];
-            Assert.AreEqual(
-                $"'{TJSheetsGenerator.RostersSheetName}'!A1:B1",
-                updateRange.Range,
-                "Unexpected range for the team names");
-            CollectionAssert.AreEquivalent(
-                new string[] { FirstTeam, SecondTeam },
-                updateRange.Values.ToArray(),
-                "Unexpected row for the team names");
-
-            updateRange = this.UpdatedRanges[1];
-            Assert.AreEqual(
-                $"'{TJSheetsGenerator.RostersSheetName}'!A2:A3",
-                updateRange.Range,
-                "Unexpected range for the first team's players");
-            CollectionAssert.AreEquivalent(
-                new string[] { "Alice", "Alan" },
-                updateRange.Values.ToArray(),
-                "Unexpected row for the first team's players");
-
-            updateRange = this.UpdatedRanges[2];
-            Assert.AreEqual(
-                $"'{TJSheetsGenerator.RostersSheetName}'!B2:B2",
-                updateRange.Range,
-                "Unexpected range for the second team's players");
-            CollectionAssert.AreEquivalent(
-                new string[] { "Bob" },
-                updateRange.Values.ToArray(),
-                "Unexpected row for the second team's players");
-        }
-
-        [TestMethod]
-        public async Task SetRostersFailsWithMoreThanSixPlayers()
-        {
-            this.TeamManager.TryAddTeam(FirstTeam, out _);
-            for (int i = 0; i < 6; i++)
-            {
-                this.TeamManager.TryAddPlayerToTeam((ulong)i, $"{i}", FirstTeam);
-            }
-
-            IResult<string> result = await this.Generator.TryUpdateRosters(this.TeamManager, SheetsUri);
-            Assert.IsTrue(result.Success, $"Update should've succeeded at the limit.");
-
-            Assert.IsTrue(
-                this.TeamManager.TryAddPlayerToTeam(1111, "OverLimit", FirstTeam),
-                "Adding the player over the limit should've succeeded");
-            result = await this.Generator.TryUpdateRosters(this.TeamManager, SheetsUri);
-            Assert.IsFalse(result.Success, $"Update should've failed after the limit.");
-            Assert.AreEqual(
-                $"Couldn't write to the sheet. Rosters can only support up to {this.Generator.PlayersPerTeamLimit} players per team.",
-                result.ErrorMessage,
-                "Unexpected error message");
+            IByRoleTeamManager teamManager = CreateDefaultTeamManager();
+            await ValidateDefaultRostersSet(teamManager);
         }
 
         [TestMethod]
         public async Task TryCreateScoresheetSucceeds()
         {
+            IByRoleTeamManager teamManager = CreateDefaultTeamManager();
+
             // Do something simple, then read the spreadsheet and verify some fields
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            this.TeamManager.TryAddTeam(FirstTeam, out _);
-            this.TeamManager.TryAddTeam(SecondTeam, out _);
-            this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam);
-            this.TeamManager.TryAddPlayerToTeam(3, "Alan", FirstTeam);
-            this.TeamManager.TryAddPlayerToTeam(4, "Bob", SecondTeam);
 
             await game.AddPlayer(2, "Alice");
             game.ScorePlayer(15);
@@ -187,19 +97,15 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         [TestMethod]
         public async Task TryCreateScoresheetWithDeadTossups()
         {
+            IByRoleTeamManager teamManager = CreateDefaultTeamManager();
+
             // Do something simple, then read the spreadsheet and verify some fields
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            this.TeamManager.TryAddTeam(FirstTeam, out _);
-            this.TeamManager.TryAddTeam(SecondTeam, out _);
-            this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam);
-            this.TeamManager.TryAddPlayerToTeam(3, "Alan", FirstTeam);
-            this.TeamManager.TryAddPlayerToTeam(4, "Bob", SecondTeam);
 
             await game.AddPlayer(2, "Alice");
             game.ScorePlayer(-5);
@@ -234,19 +140,15 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         [TestMethod]
         public async Task TryCreateScoresheetWithDeadTossupsInTiebreakers()
         {
+            IByRoleTeamManager teamManager = CreateDefaultTeamManager();
+
             // Do something simple, then read the spreadsheet and verify some fields
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            this.TeamManager.TryAddTeam(FirstTeam, out _);
-            this.TeamManager.TryAddTeam(SecondTeam, out _);
-            this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam);
-            this.TeamManager.TryAddPlayerToTeam(3, "Alan", FirstTeam);
-            this.TeamManager.TryAddPlayerToTeam(4, "Bob", SecondTeam);
 
             for (int i = 0; i < this.Generator.PhasesLimit - 1; i++)
             {
@@ -278,25 +180,21 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         [TestMethod]
         public async Task TryCreateScoresheetAtPlayerLimitSucceeds()
         {
+            List<PlayerTeamPair> players = new List<PlayerTeamPair>();
+            for (int i = 0; i < this.Generator.PlayersPerTeamLimit; i++)
+            {
+                players.Add(new PlayerTeamPair((ulong)i + 2, $"FirstPlayer{i}", FirstTeam));
+                players.Add(new PlayerTeamPair((ulong)i + 200, $"SecondPlayer{i}", SecondTeam));
+            }
+
+            ITeamManager teamManager = CreateTeamManager(players.ToArray());
+
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the first team");
-            Assert.IsTrue(this.TeamManager.TryAddTeam(SecondTeam, out _), "Couldn't add the second team");
-
-            for (int i = 0; i < this.Generator.PlayersPerTeamLimit; i++)
-            {
-                Assert.IsTrue(
-                    this.TeamManager.TryAddPlayerToTeam((ulong)i + 2, $"FirstPlayer{i}", FirstTeam),
-                    $"Couldn't add player #{i} to the first team");
-                Assert.IsTrue(
-                    this.TeamManager.TryAddPlayerToTeam((ulong)i + 200, $"SecondPlayer{i}", SecondTeam),
-                    $"Couldn't add player #{i} to the second team");
-            }
 
             IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
             Assert.IsTrue(result.Success, $"Creation should've succeeded at the limit.");
@@ -321,17 +219,14 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         [TestMethod]
         public async Task TryCreateScoresheetAtPhasesLimitSucceeds()
         {
+            IByRoleTeamManager teamManager = CreateDefaultTeamManager();
+
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the first team");
-            Assert.IsTrue(this.TeamManager.TryAddTeam(SecondTeam, out _), "Couldn't add the second team");
-            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam), "Couldn't add first player to team");
-            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(3, "Bob", SecondTeam), "Couldn't add second player to team");
 
             for (int i = 0; i < this.Generator.PhasesLimit - 1; i++)
             {
@@ -340,7 +235,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 Assert.IsTrue(game.TryScoreBonus("0"), $"Scoring a bonus should've succeeded in phase {i}");
             }
 
-            await game.AddPlayer(3, "Bob");
+            await game.AddPlayer(4, "Bob");
             game.ScorePlayer(-5);
             await game.AddPlayer(2, "Alice");
             game.ScorePlayer(15);
@@ -356,17 +251,14 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         [TestMethod]
         public async Task NoBonusesWrittenAfterBonusLimit()
         {
+            IByRoleTeamManager teamManager = CreateDefaultTeamManager();
+
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the first team");
-            Assert.IsTrue(this.TeamManager.TryAddTeam(SecondTeam, out _), "Couldn't add the second team");
-            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam), "Couldn't add first player to team");
-            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(3, "Bob", SecondTeam), "Couldn't add second player to team");
 
             int lastBonusPhase = this.Generator.LastBonusRow - this.Generator.FirstPhaseRow;
             for (int i = 0; i < lastBonusPhase; i++)
@@ -397,62 +289,19 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
-        public async Task TryCreateScoresheetPastPlayerLimitFails()
-        {
-            GameState game = new GameState()
-            {
-                Format = Format.CreateTossupShootout(false),
-                ReaderId = 1,
-                TeamManager = this.TeamManager
-            };
-
-            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the first team");
-            Assert.IsTrue(this.TeamManager.TryAddTeam(SecondTeam, out _), "Couldn't add the second team");
-
-            for (int i = 0; i < this.Generator.PlayersPerTeamLimit; i++)
-            {
-                Assert.IsTrue(
-                    this.TeamManager.TryAddPlayerToTeam((ulong)i + 2, $"Player{i}", FirstTeam),
-                    $"Couldn't add player #{i} to the first team");
-                Assert.IsTrue(
-                    this.TeamManager.TryAddPlayerToTeam((ulong)i + 200, $"Player{i}", SecondTeam),
-                    $"Couldn't add player #{i} to the second team");
-            }
-
-            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
-            Assert.IsTrue(result.Success, $"Creation should've succeeded at the limit.");
-
-            Assert.IsTrue(
-                this.TeamManager.TryAddPlayerToTeam(1111, "OverLimit", FirstTeam),
-                "Adding the player over the limit should've succeeded");
-
-            // We need to force an update to the game, so we don't have cached stats
-            await game.AddPlayer(2, "Player2");
-            game.ScorePlayer(0);
-
-            result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
-            Assert.IsFalse(result.Success, $"Creation should've failed after the limit.");
-            Assert.AreEqual(
-                $"Couldn't write to the sheet. Export only currently works if there are at most {this.Generator.PlayersPerTeamLimit} players on a team.",
-                result.ErrorMessage,
-                "Unexpected error message");
-        }
-
-        [TestMethod]
         public async Task TryCreateScoresheetOneTeamAndIndividual()
         {
             const string firstTeamPlayer = "Alice";
             const string individualName = "Individual";
 
+            IByRoleTeamManager teamManager = CreateTeamManager(new PlayerTeamPair(2, firstTeamPlayer, FirstTeam));
+
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the team");
-            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(2, firstTeamPlayer, FirstTeam), "Couldn't add player to team");
 
             await game.AddPlayer(2, firstTeamPlayer);
             game.ScorePlayer(10);
@@ -475,15 +324,13 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         [TestMethod]
         public async Task TryCreateScoresheetPastPhaseLimitFails()
         {
+            IByRoleTeamManager teamManager = CreateDefaultTeamManager();
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the team");
-            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam), "Couldn't add player to team");
 
             for (int i = 0; i < this.Generator.PhasesLimit; i++)
             {
@@ -507,85 +354,78 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
-        public async Task TryCreateScoresheetWithoutTeamsFails()
+        public async Task SetRostersWithNoRolesInChannelSucceeds()
         {
-            GameState game = new GameState()
+            PlayerTeamPair[] playerTeamPairs = new PlayerTeamPair[]
             {
-                Format = Format.CreateTossupBonusesShootout(false),
-                ReaderId = 1,
-                TeamManager = this.TeamManager
+                new PlayerTeamPair(1, "Alice", FirstTeam),
+                new PlayerTeamPair(2, "Alan", FirstTeam),
+                new PlayerTeamPair(3, "Bob", SecondTeam)
             };
+            IEnumerable<IGrouping<string, PlayerTeamPair>> grouping = playerTeamPairs.GroupBy(pair => pair.TeamId);
+            IReadOnlyDictionary<string, string> teamIdToNames = playerTeamPairs
+                .Select(pair => pair.TeamId)
+                .Distinct()
+                .ToDictionary(key => key);
 
-            await game.AddPlayer(2, "Alice");
-            game.ScorePlayer(10);
+            Mock<IByRoleTeamManager> mockTeamManager = new Mock<IByRoleTeamManager>();
+            mockTeamManager
+                .Setup(manager => manager.GetTeamIdToNamesForServer())
+                .Returns(Task.FromResult(teamIdToNames));
+            mockTeamManager
+                .Setup(manager => manager.GetPlayerTeamPairsForServer())
+                .Returns(Task.FromResult(grouping));
 
-            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
-            Assert.IsFalse(result.Success, $"Creation succeeded when it should've failed.");
+            mockTeamManager
+                .Setup(manager => manager.GetTeamIdToNames())
+                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>()));
+            mockTeamManager
+                .Setup(manager => manager.GetKnownPlayers())
+                .Returns(Task.FromResult(Enumerable.Empty<PlayerTeamPair>()));
+
+            IByRoleTeamManager teamManager = mockTeamManager.Object;
+            await ValidateDefaultRostersSet(teamManager);
+        }
+
+        private async Task ValidateDefaultRostersSet(IByRoleTeamManager teamManager)
+        {
+            IResult<string> result = await this.Generator.TryUpdateRosters(teamManager, SheetsUri);
+            Assert.IsTrue(result.Success, "Update should've succeeded");
+
+            Assert.AreEqual(1, this.ClearedRanges.Count, "Unexpected number of clears");
+            Assert.AreEqual($"'{TJSheetsGenerator.RostersSheetName}'!A1:ZZ21", this.ClearedRanges[0], "Unexpected range");
+
+            Assert.AreEqual(3, this.UpdatedRanges.Count, "Unexpected number of update ranges");
+
+            UpdateRange updateRange = this.UpdatedRanges[0];
             Assert.AreEqual(
-                "Couldn't write to the sheet. Export only works if there are 1 or 2 teams in the game.",
-                result.ErrorMessage,
-                "Unexpected error message");
-        }
+                $"'{TJSheetsGenerator.RostersSheetName}'!A1:B1",
+                updateRange.Range,
+                "Unexpected range for the team names");
+            CollectionAssert.AreEquivalent(
+                new string[] { FirstTeam, SecondTeam },
+                updateRange.Values.ToArray(),
+                "Unexpected row for the team names");
 
-        [TestMethod]
-        public async Task TryCreateScoresheetWithMoreThanTwoTeamsFails()
-        {
-            GameState game = new GameState()
-            {
-                Format = Format.CreateTossupBonusesShootout(false),
-                ReaderId = 1,
-                TeamManager = this.TeamManager
-            };
-
-            for (int i = 0; i < 3; i++)
-            {
-                string teamName = $"Team{i}";
-                Assert.IsTrue(this.TeamManager.TryAddTeam(teamName, out _), $"Couldn't add team {teamName}");
-            }
-
-            await game.AddPlayer(2, "Alice");
-            game.ScorePlayer(10);
-
-            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
-            Assert.IsFalse(result.Success, $"Creation succeeded when it should've failed.");
+            updateRange = this.UpdatedRanges[1];
             Assert.AreEqual(
-                "Couldn't write to the sheet. Export only works if there are 1 or 2 teams in the game.",
-                result.ErrorMessage,
-                "Unexpected error message");
-        }
+                $"'{TJSheetsGenerator.RostersSheetName}'!A2:A3",
+                updateRange.Range,
+                "Unexpected range for the first team's players");
+            CollectionAssert.AreEquivalent(
+                new string[] { "Alice", "Alan" },
+                updateRange.Values.ToArray(),
+                "Unexpected row for the first team's players");
 
-        private void AssertInUpdateRange(string range, string value, string message)
-        {
-            Assert.IsTrue(
-                this.UpdatedRanges
-                    .Any(valueRange => valueRange.Range == range && valueRange.Values.Any(v => v.ToString() == value)),
-                message);
-        }
-
-        private IGoogleSheetsApi CreateGoogleSheetsApi()
-        {
-            Mock<IGoogleSheetsApi> mockGoogleSheetsApi = new Mock<IGoogleSheetsApi>();
-            mockGoogleSheetsApi
-                .Setup(api => api.UpdateGoogleSheet(It.IsAny<List<ValueRange>>(), It.IsAny<List<string>>(), It.IsAny<Uri>()))
-                .Returns<List<ValueRange>, List<string>, Uri>((updateRanges, clearRanges, sheetsUri) =>
-                {
-                    this.UpdatedRanges.AddRange(updateRanges.Select(range =>
-                        new UpdateRange()
-                        {
-                            Range = range.Range,
-                            Values = range.Values.Count > 0 ? range.Values[0] : new List<object>()
-                        }));
-                    this.ClearedRanges.AddRange(clearRanges);
-                    return Task.FromResult<IResult<string>>(new SuccessResult<string>(string.Empty));
-                });
-            return mockGoogleSheetsApi.Object;
-        }
-
-        private class UpdateRange
-        {
-            public string Range { get; set; }
-
-            public IList<object> Values { get; set; }
+            updateRange = this.UpdatedRanges[2];
+            Assert.AreEqual(
+                $"'{TJSheetsGenerator.RostersSheetName}'!B2:B2",
+                updateRange.Range,
+                "Unexpected range for the second team's players");
+            CollectionAssert.AreEquivalent(
+                new string[] { "Bob" },
+                updateRange.Values.ToArray(),
+                "Unexpected row for the second team's players");
         }
     }
 }

--- a/QuizBowlDiscordScoreTrackerUnitTests/UCSDGoogleSheetsGeneratorTests.cs
+++ b/QuizBowlDiscordScoreTrackerUnitTests/UCSDGoogleSheetsGeneratorTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Google.Apis.Sheets.v4.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using QuizBowlDiscordScoreTracker;
@@ -12,110 +10,33 @@ using QuizBowlDiscordScoreTracker.TeamManager;
 namespace QuizBowlDiscordScoreTrackerUnitTests
 {
     [TestClass]
-    public class UCSDGoogleSheetsGeneratorTests
+    public class UCSDGoogleSheetsGeneratorTests : BaseGoogleSheetsGeneratorTests
     {
-        private const string FirstTeam = "Alpha";
-        private const string SecondTeam = "Beta";
-
-        private static readonly Uri SheetsUri = new Uri("http://localhost/sheets/sheetsId/");
-
-        private List<string> ClearedRanges { get; set; }
-
-        private UCSDGoogleSheetsGenerator Generator { get; set; }
-
-        private ByCommandTeamManager TeamManager { get; set; }
-
-        private List<UpdateRange> UpdatedRanges { get; set; }
-
-        [TestInitialize]
-        public void InitializeTest()
+        protected override BaseGoogleSheetsGenerator CreateGenerator(IGoogleSheetsApi sheetsApi)
         {
-            // Clear out the old fields
-            this.UpdatedRanges = new List<UpdateRange>();
-            this.ClearedRanges = new List<string>();
-            this.TeamManager = new ByCommandTeamManager();
-
-            IGoogleSheetsApi googleSheetsApi = this.CreateGoogleSheetsApi();
-            this.Generator = new UCSDGoogleSheetsGenerator(googleSheetsApi);
+            return new UCSDGoogleSheetsGenerator(sheetsApi);
         }
 
         [TestMethod]
         public async Task SetRostersSucceeds()
         {
-            this.TeamManager.TryAddTeam(FirstTeam, out _);
-            this.TeamManager.TryAddTeam(SecondTeam, out _);
-            this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam);
-            this.TeamManager.TryAddPlayerToTeam(3, "Alan", FirstTeam);
-            this.TeamManager.TryAddPlayerToTeam(4, "Bob", SecondTeam);
-
-            IResult<string> result = await this.Generator.TryUpdateRosters(this.TeamManager, SheetsUri);
-            Assert.IsTrue(result.Success, "Update should've succeeded");
-
-            Assert.AreEqual(1, this.ClearedRanges.Count, "Unexpected number of clears");
-            Assert.AreEqual($"'{UCSDGoogleSheetsGenerator.RostersSheetName}'!A2:G999", this.ClearedRanges[0], "Unexpected range");
-
-            Assert.AreEqual(2, this.UpdatedRanges.Count, "Unexpected number of update ranges");
-
-            UpdateRange updateRange = this.UpdatedRanges[0];
-            Assert.AreEqual(
-                $"'{UCSDGoogleSheetsGenerator.RostersSheetName}'!A2:C2",
-                updateRange.Range,
-                "Unexpected range for the first team");
-            CollectionAssert.AreEquivalent(
-                new string[] { FirstTeam, "Alice", "Alan" },
-                updateRange.Values.ToArray(),
-                "Unexpected row for the first team");
-
-            updateRange = this.UpdatedRanges[1];
-            Assert.AreEqual(
-                $"'{UCSDGoogleSheetsGenerator.RostersSheetName}'!A3:B3",
-                updateRange.Range,
-                "Unexpected range for the second team");
-            CollectionAssert.AreEquivalent(
-                new string[] { SecondTeam, "Bob" },
-                updateRange.Values.ToArray(),
-                "Unexpected row for the second team");
-        }
-
-        [TestMethod]
-        public async Task SetRostersFailsWithMoreThanSixPlayers()
-        {
-            this.TeamManager.TryAddTeam(FirstTeam, out _);
-            for (int i = 0; i < 6; i++)
-            {
-                this.TeamManager.TryAddPlayerToTeam((ulong)i, $"{i}", FirstTeam);
-            }
-
-            IResult<string> result = await this.Generator.TryUpdateRosters(this.TeamManager, SheetsUri);
-            Assert.IsTrue(result.Success, $"Update should've succeeded at the limit.");
-
-            Assert.IsTrue(
-                this.TeamManager.TryAddPlayerToTeam(1111, "OverLimit", FirstTeam),
-                "Adding the player over the limit should've succeeded");
-            result = await this.Generator.TryUpdateRosters(this.TeamManager, SheetsUri);
-            Assert.IsFalse(result.Success, $"Update should've failed after the limit.");
-            Assert.AreEqual(
-                $"Couldn't write to the sheet. Rosters can only support up to {this.Generator.PlayersPerTeamLimit} players per team.",
-                result.ErrorMessage,
-                "Unexpected error message");
+            IByRoleTeamManager teamManager = CreateDefaultTeamManager();
+            await ValidateDefaultRostersSet(teamManager);
         }
 
         [TestMethod]
         public async Task TryCreateScoresheetSucceeds()
         {
             // Do something simple, then read the spreadsheet and verify some fields
+            IByRoleTeamManager teamManager = CreateDefaultTeamManager();
+
+            // Do something simple, then read the spreadsheet and verify some fields
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            this.TeamManager.TryAddTeam(FirstTeam, out _);
-            this.TeamManager.TryAddTeam(SecondTeam, out _);
-            this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam);
-            this.TeamManager.TryAddPlayerToTeam(3, "Alan", FirstTeam);
-            this.TeamManager.TryAddPlayerToTeam(4, "Bob", SecondTeam);
 
             await game.AddPlayer(2, "Alice");
             game.ScorePlayer(15);
@@ -177,25 +98,21 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         [TestMethod]
         public async Task TryCreateScoresheetAtPlayerLimitSucceeds()
         {
+            List<PlayerTeamPair> players = new List<PlayerTeamPair>();
+            for (int i = 0; i < this.Generator.PlayersPerTeamLimit; i++)
+            {
+                players.Add(new PlayerTeamPair((ulong)i + 2, $"FirstPlayer{i}", FirstTeam));
+                players.Add(new PlayerTeamPair((ulong)i + 200, $"SecondPlayer{i}", SecondTeam));
+            }
+
+            ITeamManager teamManager = CreateTeamManager(players.ToArray());
+
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the first team");
-            Assert.IsTrue(this.TeamManager.TryAddTeam(SecondTeam, out _), "Couldn't add the second team");
-
-            for (int i = 0; i < this.Generator.PlayersPerTeamLimit; i++)
-            {
-                Assert.IsTrue(
-                    this.TeamManager.TryAddPlayerToTeam((ulong)i + 2, $"FirstPlayer{i}", FirstTeam),
-                    $"Couldn't add player #{i} to the first team");
-                Assert.IsTrue(
-                    this.TeamManager.TryAddPlayerToTeam((ulong)i + 200, $"SecondPlayer{i}", SecondTeam),
-                    $"Couldn't add player #{i} to the second team");
-            }
 
             IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
             Assert.IsTrue(result.Success, $"Creation should've succeeded at the limit.");
@@ -220,17 +137,14 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         [TestMethod]
         public async Task TryCreateScoresheetAtPhasesLimitSucceeds()
         {
+            IByRoleTeamManager teamManager = CreateDefaultTeamManager();
+
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the first team");
-            Assert.IsTrue(this.TeamManager.TryAddTeam(SecondTeam, out _), "Couldn't add the second team");
-            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam), "Couldn't add first player to team");
-            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(3, "Bob", SecondTeam), "Couldn't add second player to team");
 
             for (int i = 0; i < this.Generator.PhasesLimit - 1; i++)
             {
@@ -239,7 +153,7 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
                 Assert.IsTrue(game.TryScoreBonus("0"), $"Scoring a bonus should've succeeded in phase {i}");
             }
 
-            await game.AddPlayer(3, "Bob");
+            await game.AddPlayer(4, "Bob");
             game.ScorePlayer(-5);
             await game.AddPlayer(2, "Alice");
             game.ScorePlayer(15);
@@ -255,17 +169,14 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         [TestMethod]
         public async Task NoBonusesWrittenAfterBonusLimit()
         {
+            IByRoleTeamManager teamManager = CreateDefaultTeamManager();
+
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupBonusesShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the first team");
-            Assert.IsTrue(this.TeamManager.TryAddTeam(SecondTeam, out _), "Couldn't add the second team");
-            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam), "Couldn't add first player to team");
-            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(3, "Bob", SecondTeam), "Couldn't add second player to team");
 
             int lastBonusPhase = this.Generator.LastBonusRow - this.Generator.FirstPhaseRow;
             for (int i = 0; i < lastBonusPhase; i++)
@@ -296,62 +207,19 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
-        public async Task TryCreateScoresheetPastPlayerLimitFails()
-        {
-            GameState game = new GameState()
-            {
-                Format = Format.CreateTossupShootout(false),
-                ReaderId = 1,
-                TeamManager = this.TeamManager
-            };
-
-            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the first team");
-            Assert.IsTrue(this.TeamManager.TryAddTeam(SecondTeam, out _), "Couldn't add the second team");
-
-            for (int i = 0; i < this.Generator.PlayersPerTeamLimit; i++)
-            {
-                Assert.IsTrue(
-                    this.TeamManager.TryAddPlayerToTeam((ulong)i + 2, $"Player{i}", FirstTeam),
-                    $"Couldn't add player #{i} to the first team");
-                Assert.IsTrue(
-                    this.TeamManager.TryAddPlayerToTeam((ulong)i + 200, $"Player{i}", SecondTeam),
-                    $"Couldn't add player #{i} to the second team");
-            }
-
-            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
-            Assert.IsTrue(result.Success, $"Creation should've succeeded at the limit.");
-
-            Assert.IsTrue(
-                this.TeamManager.TryAddPlayerToTeam(1111, "OverLimit", FirstTeam),
-                "Adding the player over the limit should've succeeded");
-
-            // We need to force an update to the game, so we don't have cached stats
-            await game.AddPlayer(2, "Player2");
-            game.ScorePlayer(0);
-
-            result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
-            Assert.IsFalse(result.Success, $"Creation should've failed after the limit.");
-            Assert.AreEqual(
-                $"Couldn't write to the sheet. Export only currently works if there are at most {this.Generator.PlayersPerTeamLimit} players on a team.",
-                result.ErrorMessage,
-                "Unexpected error message");
-        }
-
-        [TestMethod]
         public async Task TryCreateScoresheetOneTeamAndIndividual()
         {
             const string firstTeamPlayer = "Alice";
             const string individualName = "Individual";
 
+            IByRoleTeamManager teamManager = CreateTeamManager(new PlayerTeamPair(2, firstTeamPlayer, FirstTeam));
+
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the team");
-            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(2, firstTeamPlayer, FirstTeam), "Couldn't add player to team");
 
             await game.AddPlayer(2, firstTeamPlayer);
             game.ScorePlayer(10);
@@ -374,15 +242,13 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         [TestMethod]
         public async Task TryCreateScoresheetPastPhaseLimitFails()
         {
+            IByRoleTeamManager teamManager = CreateDefaultTeamManager();
             GameState game = new GameState()
             {
                 Format = Format.CreateTossupShootout(false),
                 ReaderId = 1,
-                TeamManager = this.TeamManager
+                TeamManager = teamManager
             };
-
-            Assert.IsTrue(this.TeamManager.TryAddTeam(FirstTeam, out _), "Couldn't add the team");
-            Assert.IsTrue(this.TeamManager.TryAddPlayerToTeam(2, "Alice", FirstTeam), "Couldn't add player to team");
 
             for (int i = 0; i < this.Generator.PhasesLimit; i++)
             {
@@ -406,85 +272,68 @@ namespace QuizBowlDiscordScoreTrackerUnitTests
         }
 
         [TestMethod]
-        public async Task TryCreateScoresheetWithoutTeamsFails()
+        public async Task SetRostersWithNoRolesInChannelSucceeds()
         {
-            GameState game = new GameState()
+            PlayerTeamPair[] playerTeamPairs = new PlayerTeamPair[]
             {
-                Format = Format.CreateTossupBonusesShootout(false),
-                ReaderId = 1,
-                TeamManager = this.TeamManager
+                new PlayerTeamPair(1, "Alice", FirstTeam),
+                new PlayerTeamPair(2, "Alan", FirstTeam),
+                new PlayerTeamPair(3, "Bob", SecondTeam)
             };
+            IEnumerable<IGrouping<string, PlayerTeamPair>> grouping = playerTeamPairs.GroupBy(pair => pair.TeamId);
+            IReadOnlyDictionary<string, string> teamIdToNames = playerTeamPairs
+                .Select(pair => pair.TeamId)
+                .Distinct()
+                .ToDictionary(key => key);
 
-            await game.AddPlayer(2, "Alice");
-            game.ScorePlayer(10);
+            Mock<IByRoleTeamManager> mockTeamManager = new Mock<IByRoleTeamManager>();
+            mockTeamManager
+                .Setup(manager => manager.GetTeamIdToNamesForServer())
+                .Returns(Task.FromResult(teamIdToNames));
+            mockTeamManager
+                .Setup(manager => manager.GetPlayerTeamPairsForServer())
+                .Returns(Task.FromResult(grouping));
 
-            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
-            Assert.IsFalse(result.Success, $"Creation succeeded when it should've failed.");
+            mockTeamManager
+                .Setup(manager => manager.GetTeamIdToNames())
+                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>()));
+            mockTeamManager
+                .Setup(manager => manager.GetKnownPlayers())
+                .Returns(Task.FromResult(Enumerable.Empty<PlayerTeamPair>()));
+
+            IByRoleTeamManager teamManager = mockTeamManager.Object;
+            await ValidateDefaultRostersSet(teamManager);
+        }
+
+        private async Task ValidateDefaultRostersSet(IByRoleTeamManager teamManager)
+        {
+            IResult<string> result = await this.Generator.TryUpdateRosters(teamManager, SheetsUri);
+            Assert.IsTrue(result.Success, "Update should've succeeded");
+
+            Assert.AreEqual(1, this.ClearedRanges.Count, "Unexpected number of clears");
+            Assert.AreEqual($"'{UCSDGoogleSheetsGenerator.RostersSheetName}'!A2:G999", this.ClearedRanges[0], "Unexpected range");
+
+            Assert.AreEqual(2, this.UpdatedRanges.Count, "Unexpected number of update ranges");
+
+            UpdateRange updateRange = this.UpdatedRanges[0];
             Assert.AreEqual(
-                "Couldn't write to the sheet. Export only works if there are 1 or 2 teams in the game.",
-                result.ErrorMessage,
-                "Unexpected error message");
-        }
+                $"'{UCSDGoogleSheetsGenerator.RostersSheetName}'!A2:C2",
+                updateRange.Range,
+                "Unexpected range for the first team");
+            CollectionAssert.AreEquivalent(
+                new string[] { FirstTeam, "Alice", "Alan" },
+                updateRange.Values.ToArray(),
+                "Unexpected row for the first team");
 
-        [TestMethod]
-        public async Task TryCreateScoresheetWithMoreThanTwoTeamsFails()
-        {
-            GameState game = new GameState()
-            {
-                Format = Format.CreateTossupBonusesShootout(false),
-                ReaderId = 1,
-                TeamManager = this.TeamManager
-            };
-
-            for (int i = 0; i < 3; i++)
-            {
-                string teamName = $"Team{i}";
-                Assert.IsTrue(this.TeamManager.TryAddTeam(teamName, out _), $"Couldn't add team {teamName}");
-            }
-
-            await game.AddPlayer(2, "Alice");
-            game.ScorePlayer(10);
-
-            IResult<string> result = await this.Generator.TryCreateScoresheet(game, SheetsUri, 1);
-            Assert.IsFalse(result.Success, $"Creation succeeded when it should've failed.");
+            updateRange = this.UpdatedRanges[1];
             Assert.AreEqual(
-                "Couldn't write to the sheet. Export only works if there are 1 or 2 teams in the game.",
-                result.ErrorMessage,
-                "Unexpected error message");
-        }
-
-        private void AssertInUpdateRange(string range, string value, string message)
-        {
-            Assert.IsTrue(
-                this.UpdatedRanges
-                    .Any(valueRange => valueRange.Range == range && valueRange.Values.Any(v => v.ToString() == value)),
-                message);
-        }
-
-        private IGoogleSheetsApi CreateGoogleSheetsApi()
-        {
-            Mock<IGoogleSheetsApi> mockGoogleSheetsApi = new Mock<IGoogleSheetsApi>();
-            mockGoogleSheetsApi
-                .Setup(api => api.UpdateGoogleSheet(It.IsAny<List<ValueRange>>(), It.IsAny<List<string>>(), It.IsAny<Uri>()))
-                .Returns<List<ValueRange>, List<string>, Uri>((updateRanges, clearRanges, sheetsUri) =>
-                {
-                    this.UpdatedRanges.AddRange(updateRanges.Select(range =>
-                        new UpdateRange()
-                        {
-                            Range = range.Range,
-                            Values = range.Values.Count > 0 ? range.Values[0] : new List<object>()
-                        }));
-                    this.ClearedRanges.AddRange(clearRanges);
-                    return Task.FromResult<IResult<string>>(new SuccessResult<string>(string.Empty));
-                });
-            return mockGoogleSheetsApi.Object;
-        }
-
-        private class UpdateRange
-        {
-            public string Range { get; set; }
-
-            public IList<object> Values { get; set; }
+                $"'{UCSDGoogleSheetsGenerator.RostersSheetName}'!A3:B3",
+                updateRange.Range,
+                "Unexpected range for the second team");
+            CollectionAssert.AreEquivalent(
+                new string[] { SecondTeam, "Bob" },
+                updateRange.Values.ToArray(),
+                "Unexpected row for the second team");
         }
     }
 }


### PR DESCRIPTION
…f they didn't have access to the channel

- Fix a bug where we ignored team roles that didn't have access to a the channel where the !setRosters command was called (#86) 
- Bump version to 3.8.2